### PR TITLE
Add Copilot setup steps workflow for .NET 10

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,33 @@
+name: "Copilot Setup Steps"
+
+on:
+    workflow_dispatch:
+    push:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+    pull_request:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+    # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+    copilot-setup-steps:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
+
+            - name: Set up .NET 10
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "10.0.x"
+
+            - name: Restore dependencies
+              run: dotnet restore Mcp.sln
+
+            - name: Build solution
+              run: dotnet build Mcp.sln --no-restore --configuration Debug

--- a/Mcp.sln
+++ b/Mcp.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolsLibrary", "src\ToolsLi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpMcpServer", "src\HttpMcpServer\HttpMcpServer.csproj", "{FC243199-26D9-42CC-AB94-809A9570E273}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpClient", "src\MCPClient\McpClient.csproj", "{F734AB09-82A2-4167-860E-78053312AD96}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpClient", "src\McpClient\McpClient.csproj", "{F734AB09-82A2-4167-860E-78053312AD96}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_SolutionItems", "_SolutionItems", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
## Why

GitHub Copilot coding agent needs a pre-configured environment to work effectively in this repository. Without a setup workflow, Copilot sessions start without the correct SDK or restored dependencies, leading to build failures and wasted cycles.

## What this does

Adds a `copilot-setup-steps.yml` workflow that prepares the environment for Copilot by:

- Checking out the repository
- Installing .NET 10 SDK
- Restoring NuGet dependencies for `Mcp.sln`
- Building the solution in Debug configuration

The workflow runs on `ubuntu-latest` and is triggered on pushes/PRs that modify the workflow file itself, as well as via `workflow_dispatch` for manual runs.

## Notes

- The job is named `copilot-setup-steps` as required by Copilot's convention for automatic detection.
- Only `contents: read` permission is requested to follow least-privilege principles.