### PR TITLE
feat: add sales assistant MCP tools and split scopes

### DIFF
--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.Identity.Web;
+using ToolsLibrary.Data;
 using ToolsLibrary.Prompts;
 using ToolsLibrary.Resources;
 using ToolsLibrary.Tools;
@@ -24,6 +25,8 @@ builder.Services.AddAuthentication()
 
 builder.Services.AddAuthorization();
 
+builder.Services.AddSingleton<SalesDataStore>();
+
 builder.Services
        .AddMcpServer()
     .WithHttpTransport(options =>
@@ -33,7 +36,8 @@ builder.Services
        .WithPrompts<PromptExamples>()
        .WithResources<DocumentationResource>()
        .WithTools<RandomNumberTools>()
-       .WithTools<DateTools>();
+       .WithTools<DateTools>()
+       .WithTools<SalesTools>();
 
 // Add CORS for HTTP transport support in browsers
 builder.Services.AddCors(options =>

--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -55,6 +55,7 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddHttpClient();
+builder.Services.AddHttpContextAccessor();
 
 static bool HasScope(Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext context, string requiredScope)
 {
@@ -70,6 +71,8 @@ static bool HasScope(Microsoft.AspNetCore.Authorization.AuthorizationHandlerCont
 
 // The scope must be validated to force delegated access tokens intended for this API.
 builder.Services.AddAuthorizationBuilder()
+  .AddPolicy("mcp_any", policy =>
+        policy.RequireAssertion(context => HasScope(context, "mcp:sales") || HasScope(context, "mcp:demo")))
   .AddPolicy("mcp_sales", policy =>
         policy.RequireAssertion(context => HasScope(context, "mcp:sales")))
   .AddPolicy("mcp_demo", policy =>
@@ -89,7 +92,6 @@ app.MapGet("/health", () => $"Secure MCP server running deployed: UTC: {DateTime
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapMcp("/mcp/sales").RequireAuthorization("mcp_sales");
-app.MapMcp("/mcp").RequireAuthorization("mcp_demo");
+app.MapMcp("/mcp").RequireAuthorization("mcp_any");
 
 app.Run();

--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -56,14 +56,24 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddHttpClient();
 
-// change to scp or scope if not using magic namespaces from MS
-// The scope must be validated as we want to force only delegated access tokens
-// The scope is required to only allow access tokens intended for this API
+static bool HasScope(Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext context, string requiredScope)
+{
+    var scopeClaimValues = context.User
+        .FindAll("http://schemas.microsoft.com/identity/claims/scope")
+        .Select(c => c.Value)
+        .Concat(context.User.FindAll("scp").Select(c => c.Value));
+
+    return scopeClaimValues
+        .SelectMany(v => v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        .Any(s => string.Equals(s, requiredScope, StringComparison.Ordinal));
+}
+
+// The scope must be validated to force delegated access tokens intended for this API.
 builder.Services.AddAuthorizationBuilder()
   .AddPolicy("mcp_sales", policy =>
-        policy.RequireClaim("http://schemas.microsoft.com/identity/claims/scope", "mcp:sales"))
+        policy.RequireAssertion(context => HasScope(context, "mcp:sales")))
   .AddPolicy("mcp_demo", policy =>
-        policy.RequireClaim("http://schemas.microsoft.com/identity/claims/scope", "mcp:demo"));
+        policy.RequireAssertion(context => HasScope(context, "mcp:demo")));
 
 // Add services to the container.
 var app = builder.Build();

--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddAuthentication()
 builder.Services.AddAuthorization();
 
 builder.Services.AddSingleton<SalesDataStore>();
+builder.Services.AddTransient<SalesTools>();
 
 builder.Services
        .AddMcpServer()

--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -19,7 +19,10 @@ builder.Services.AddAuthentication()
         Resource = $"{httpMcpServerUrl!}/mcp",
         AuthorizationServers = [authority],
         ResourceDocumentation = $"{httpMcpServerUrl}/health",
-        ScopesSupported = [builder.Configuration["McpScope"]!],
+        ScopesSupported = [
+            builder.Configuration["McpSalesScope"]!,
+            builder.Configuration["McpDemoScope"]!
+        ],
     };
 });
 
@@ -55,10 +58,12 @@ builder.Services.AddHttpClient();
 
 // change to scp or scope if not using magic namespaces from MS
 // The scope must be validated as we want to force only delegated access tokens
-// The scope is requires to only allow access tokens intended for this API
+// The scope is required to only allow access tokens intended for this API
 builder.Services.AddAuthorizationBuilder()
-  .AddPolicy("mcp_tools", policy =>
-        policy.RequireClaim("http://schemas.microsoft.com/identity/claims/scope", "mcp:tools"));
+  .AddPolicy("mcp_sales", policy =>
+        policy.RequireClaim("http://schemas.microsoft.com/identity/claims/scope", "mcp:sales"))
+  .AddPolicy("mcp_demo", policy =>
+        policy.RequireClaim("http://schemas.microsoft.com/identity/claims/scope", "mcp:demo"));
 
 // Add services to the container.
 var app = builder.Build();
@@ -74,6 +79,7 @@ app.MapGet("/health", () => $"Secure MCP server running deployed: UTC: {DateTime
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapMcp("/mcp").RequireAuthorization("mcp_tools");
+app.MapMcp("/mcp/sales").RequireAuthorization("mcp_sales");
+app.MapMcp("/mcp").RequireAuthorization("mcp_demo");
 
 app.Run();

--- a/src/HttpMcpServer/appsettings.Development.json
+++ b/src/HttpMcpServer/appsettings.Development.json
@@ -1,5 +1,7 @@
 {
   "HttpMcpServerUrl": "https://localhost:7133",
+  "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
+  "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/HttpMcpServer/appsettings.json
+++ b/src/HttpMcpServer/appsettings.json
@@ -1,6 +1,7 @@
 {
   "HttpMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net",
-  "McpScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:tools",
+  "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
+  "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/McpClient/appsettings.json
+++ b/src/McpClient/appsettings.json
@@ -6,6 +6,6 @@
   "ClientId": "5644788a-f249-4cfa-81d7-fd73bad64f15",
   "TenantId": "be8b7aa3-8763-4c4e-a6a1-96b79d52eba5",
   "RedirectUri": "http://localhost",
-  "McpScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:tools"
+  "McpScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo"
 
 }

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -128,7 +128,7 @@ public class ChatService
         if (_functionCallingMode == FunctionCallingMode.McpSecure)
         {
             clientName = "Secure Client";
-            var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
+            var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpDemoScope"]!]);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         }
 

--- a/src/McpWebClient/AiServices/Models/SalesResponse.cs
+++ b/src/McpWebClient/AiServices/Models/SalesResponse.cs
@@ -1,0 +1,30 @@
+namespace McpWebClient.AiServices.Models;
+
+public record SalesCustomerView(
+    string Id,
+    string Name,
+    string Industry,
+    string Tier,
+    string AccountManager
+);
+
+public record SalesOrderView(
+    string Id,
+    string CustomerId,
+    string CustomerName,
+    string ProductName,
+    string Status,
+    DateTime OrderDate,
+    DateTime PromisedDeliveryDate,
+    DateTime? ActualDeliveryDate,
+    decimal Value
+);
+
+public record SalesChatMessage(string Role, string Content);
+
+public record SalesResponse(
+    string? FinalAnswer,
+    List<SalesChatMessage> ChatHistory,
+    List<SalesCustomerView> Customers,
+    List<SalesOrderView> Orders
+);

--- a/src/McpWebClient/AiServices/Models/SalesResponse.cs
+++ b/src/McpWebClient/AiServices/Models/SalesResponse.cs
@@ -22,9 +22,12 @@ public record SalesOrderView(
 
 public record SalesChatMessage(string Role, string Content);
 
+public record McpToolCall(string ToolName, string? Arguments, bool Success);
+
 public record SalesResponse(
     string? FinalAnswer,
     List<SalesChatMessage> ChatHistory,
     List<SalesCustomerView> Customers,
-    List<SalesOrderView> Orders
+    List<SalesOrderView> Orders,
+    List<McpToolCall> ToolCalls
 );

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -95,8 +95,8 @@ public class SalesAssistantService
                     session.History.Add(msg);
             }
 
-            // Refresh context data after the AI turn (reuse already-fetched tools)
-            (customers, orders) = await RefreshContextAsync(tools);
+            // Build context from actual tool results returned this turn
+            (customers, orders) = ExtractContextFromToolResults(response.Messages);
 
             var chatHistory = BuildChatHistory(session.History);
             return new SalesResponse(finalAnswer, chatHistory, customers, orders, toolCalls);
@@ -139,24 +139,59 @@ public class SalesAssistantService
         }, httpClient, NullLoggerFactory.Instance, ownsHttpClient: false);
     }
 
-    private static async Task<(List<SalesCustomerView>, List<SalesOrderView>)> RefreshContextAsync(IList<AIFunction> tools)
+    /// <summary>
+    /// Builds context data from the tool results actually returned in this turn's response messages.
+    /// Only shows the data the LLM actually fetched — delayed orders show only delayed, etc.
+    /// </summary>
+    private static (List<SalesCustomerView>, List<SalesOrderView>) ExtractContextFromToolResults(
+        IEnumerable<ChatMessage> messages)
     {
-        var customerTool = tools.FirstOrDefault(t => t.Name == "get_all_customers");
-        var orderTool = tools.FirstOrDefault(t => t.Name == "get_all_orders");
+        // Map callId → (toolName, jsonResult)
+        var callNames = new Dictionary<string, string>();
+        var callResults = new Dictionary<string, string>();
+
+        foreach (var msg in messages)
+        {
+            foreach (var content in msg.Contents)
+            {
+                if (content is FunctionCallContent call)
+                    callNames[call.CallId] = call.Name;
+                else if (content is FunctionResultContent result)
+                    callResults[result.CallId] = result.Result?.ToString() ?? string.Empty;
+            }
+        }
 
         List<SalesCustomerView> customers = [];
         List<SalesOrderView> orders = [];
 
-        if (customerTool != null)
+        foreach (var (callId, toolName) in callNames)
         {
-            var result = await customerTool.InvokeAsync(null);
-            customers = DeserializeCustomers(result?.ToString());
-        }
+            if (!callResults.TryGetValue(callId, out var json) || string.IsNullOrWhiteSpace(json))
+                continue;
 
-        if (orderTool != null)
-        {
-            var result = await orderTool.InvokeAsync(null);
-            orders = DeserializeOrders(result?.ToString());
+            switch (toolName)
+            {
+                case "get_all_customers":
+                    customers = DeserializeCustomers(json);
+                    break;
+
+                case "get_all_orders":
+                case "get_delayed_orders":
+                case "get_customer_orders":
+                    var fetchedOrders = DeserializeOrders(json);
+                    // merge into orders list (avoid duplicates when multiple order tools are called)
+                    var existingIds = orders.Select(o => o.Id).ToHashSet();
+                    orders.AddRange(fetchedOrders.Where(o => !existingIds.Contains(o.Id)));
+                    // populate customers from order data when no explicit customer call was made
+                    if (customers.Count == 0)
+                    {
+                        customers = fetchedOrders
+                            .GroupBy(o => o.CustomerId)
+                            .Select(g => new SalesCustomerView(g.Key, g.First().CustomerName, string.Empty, string.Empty, string.Empty))
+                            .ToList();
+                    }
+                    break;
+            }
         }
 
         return (customers, orders);

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -32,35 +32,32 @@ public class SalesAssistantService
         _tokenAcquisition = tokenAcquisition;
     }
 
-    public async Task<SalesResponse> BeginAsync(string userKey, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    public async Task<SalesResponse> BeginAsync(string userKey, string prompt, IHttpClientFactory clientFactory)
     {
         var session = new SalesSession();
         _sessions[userKey] = session;
-        return await ChatAsync(session, prompt, mode, clientFactory);
+        return await ChatAsync(session, prompt, clientFactory);
     }
 
-    public async Task<SalesResponse> ContinueAsync(string userKey, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    public async Task<SalesResponse> ContinueAsync(string userKey, string prompt, IHttpClientFactory clientFactory)
     {
         if (!_sessions.TryGetValue(userKey, out var session))
         {
             session = new SalesSession();
             _sessions[userKey] = session;
         }
-        return await ChatAsync(session, prompt, mode, clientFactory);
+        return await ChatAsync(session, prompt, clientFactory);
     }
 
     public void Clear(string userKey) => _sessions.TryRemove(userKey, out _);
 
     // -------------------------------------------------------------------------
 
-    private async Task<SalesResponse> ChatAsync(SalesSession session, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    private async Task<SalesResponse> ChatAsync(SalesSession session, string prompt, IHttpClientFactory clientFactory)
     {
-        if (mode == FunctionCallingMode.Local)
-            throw new InvalidOperationException("Sales Assistant requires an MCP server connection (Unsecure or Secure mode).");
-
         session.History.Add(new ChatMessage(ChatRole.User, prompt));
 
-        var (chatClient, mcpClient) = await CreateClientsAsync(mode, clientFactory);
+        var (chatClient, mcpClient) = await CreateClientsAsync(clientFactory);
         List<SalesCustomerView> customers = [];
         List<SalesOrderView> orders = [];
 
@@ -105,7 +102,7 @@ public class SalesAssistantService
         }
     }
 
-    private async Task<(IChatClient, McpClient)> CreateClientsAsync(FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    private async Task<(IChatClient, McpClient)> CreateClientsAsync(IHttpClientFactory clientFactory)
     {
         var config = new ConfigurationBuilder()
             .AddUserSecrets<Program>()
@@ -113,20 +110,17 @@ public class SalesAssistantService
             .Build();
 
         var chatClient = ChatClientHelper.GetChatClient(config);
-        var transport = await CreateTransportAsync(mode, clientFactory);
+        var transport = await CreateTransportAsync(clientFactory);
         var mcpClient = await McpClient.CreateAsync(transport);
         return (chatClient, mcpClient);
     }
 
-    private async Task<IClientTransport> CreateTransportAsync(FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    private async Task<IClientTransport> CreateTransportAsync(IHttpClientFactory clientFactory)
     {
         var httpClient = clientFactory.CreateClient();
 
-        if (mode == FunctionCallingMode.McpSecure)
-        {
-            var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        }
+        var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
         var serverUrl = _configuration["HttpMcpServerUrl"]
             ?? throw new InvalidOperationException("HttpMcpServerUrl is not configured.");
@@ -134,7 +128,7 @@ public class SalesAssistantService
         return new HttpClientTransport(new HttpClientTransportOptions
         {
             Endpoint = new Uri(serverUrl),
-            Name = mode == FunctionCallingMode.McpSecure ? "Secure Sales Client" : "Unsecure Sales Client",
+            Name = "Secure Sales Client",
             TransportMode = HttpTransportMode.StreamableHttp,
         }, httpClient, NullLoggerFactory.Instance, ownsHttpClient: false);
     }

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -1,9 +1,9 @@
-using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using ClientLibrary;
 using McpWebClient.AiServices.Models;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Identity.Web;
 using ModelContextProtocol.Client;
@@ -13,6 +13,7 @@ namespace McpWebClient.AiServices;
 
 public class SalesAssistantService
 {
+    private const int MaxHistoryMessages = 40;
     private const string SystemPrompt =
         "You are a Sales Assistant with direct access to sales data through built-in tools. " +
         "Available tools: get_all_customers, get_all_orders, get_customer_orders, get_delayed_orders. " +
@@ -23,39 +24,50 @@ public class SalesAssistantService
 
     private readonly IConfiguration _configuration;
     private readonly ITokenAcquisition _tokenAcquisition;
+    private readonly IMemoryCache _sessionCache;
+    private static readonly MemoryCacheEntryOptions SessionCacheOptions = new()
+    {
+        SlidingExpiration = TimeSpan.FromMinutes(30),
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(8)
+    };
 
-    private static readonly ConcurrentDictionary<string, SalesSession> _sessions = new();
-
-    public SalesAssistantService(IConfiguration configuration, ITokenAcquisition tokenAcquisition)
+    public SalesAssistantService(
+        IConfiguration configuration,
+        ITokenAcquisition tokenAcquisition,
+        IMemoryCache sessionCache)
     {
         _configuration = configuration;
         _tokenAcquisition = tokenAcquisition;
+        _sessionCache = sessionCache;
     }
 
     public async Task<SalesResponse> BeginAsync(string userKey, string prompt, IHttpClientFactory clientFactory)
     {
         var session = new SalesSession();
-        _sessions[userKey] = session;
-        return await ChatAsync(session, prompt, clientFactory);
+        var response = await ChatAsync(session, prompt, clientFactory);
+        _sessionCache.Set(GetSessionCacheKey(userKey), session, SessionCacheOptions);
+        return response;
     }
 
     public async Task<SalesResponse> ContinueAsync(string userKey, string prompt, IHttpClientFactory clientFactory)
     {
-        if (!_sessions.TryGetValue(userKey, out var session))
-        {
-            session = new SalesSession();
-            _sessions[userKey] = session;
-        }
-        return await ChatAsync(session, prompt, clientFactory);
+        var cacheKey = GetSessionCacheKey(userKey);
+        _sessionCache.TryGetValue(cacheKey, out SalesSession? cachedSession);
+        var session = cachedSession ?? new SalesSession();
+
+        var response = await ChatAsync(session, prompt, clientFactory);
+        _sessionCache.Set(cacheKey, session, SessionCacheOptions);
+        return response;
     }
 
-    public void Clear(string userKey) => _sessions.TryRemove(userKey, out _);
+    public void Clear(string userKey) => _sessionCache.Remove(GetSessionCacheKey(userKey));
 
     // -------------------------------------------------------------------------
 
     private async Task<SalesResponse> ChatAsync(SalesSession session, string prompt, IHttpClientFactory clientFactory)
     {
         session.History.Add(new ChatMessage(ChatRole.User, prompt));
+        TrimHistory(session);
 
         var (chatClient, mcpClient) = await CreateClientsAsync(clientFactory);
         List<SalesCustomerView> customers = [];
@@ -83,7 +95,7 @@ public class SalesAssistantService
             messagesWithSystem.AddRange(session.History);
 
             var response = await wrappedClient.GetResponseAsync(messagesWithSystem, chatOptions);
-            var finalAnswer = response.Messages.LastOrDefault(m => m.Role == ChatRole.Assistant)?.Text;
+            var finalAnswer = GetMessageText(response.Messages.LastOrDefault(m => m.Role == ChatRole.Assistant));
 
             // Extract MCP tool calls made during this turn for display
             var toolCalls = ExtractToolCalls(response.Messages);
@@ -94,6 +106,7 @@ public class SalesAssistantService
                 if (msg.Role == ChatRole.Assistant || msg.Role == ChatRole.Tool)
                     session.History.Add(msg);
             }
+            TrimHistory(session);
 
             // Build context from actual tool results returned this turn
             (customers, orders) = ExtractContextFromToolResults(response.Messages);
@@ -286,9 +299,48 @@ public class SalesAssistantService
     private static List<SalesChatMessage> BuildChatHistory(List<ChatMessage> history) =>
         history
             .Where(m => m.Role == ChatRole.User || m.Role == ChatRole.Assistant)
-            .Where(m => !string.IsNullOrWhiteSpace(m.Text))
-            .Select(m => new SalesChatMessage(m.Role == ChatRole.User ? "user" : "assistant", m.Text ?? string.Empty))
+            .Select(m => new
+            {
+                Role = m.Role == ChatRole.User ? "user" : "assistant",
+                Content = GetMessageText(m)
+            })
+            .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+            .Select(m => new SalesChatMessage(m.Role, m.Content!))
             .ToList();
+
+    private static string? GetMessageText(ChatMessage? message)
+    {
+        if (message == null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(message.Text))
+        {
+            return message.Text;
+        }
+
+        var textParts = message.Contents
+            .OfType<TextContent>()
+            .Select(c => c.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
+        return textParts.Count == 0 ? null : string.Join(Environment.NewLine, textParts);
+    }
+
+    private static string GetSessionCacheKey(string userKey) => $"sales-session:{userKey}";
+
+    private static void TrimHistory(SalesSession session)
+    {
+        if (session.History.Count <= MaxHistoryMessages)
+        {
+            return;
+        }
+
+        var removeCount = session.History.Count - MaxHistoryMessages;
+        session.History.RemoveRange(0, removeCount);
+    }
 
     private class SalesSession
     {

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -14,11 +14,12 @@ namespace McpWebClient.AiServices;
 public class SalesAssistantService
 {
     private const string SystemPrompt =
-        "You are a Sales Copilot for a CRM/ERP system. " +
-        "Help the user analyze customer orders, identify delivery delays, and assess customer risk. " +
-        "Use the available tools to retrieve customer and order data. " +
-        "When assessing risk, consider: customer tier (A is most critical), number of delayed orders, " +
-        "delay duration, and order value. Be concise and actionable in your responses.";
+        "You are a Sales Assistant with direct access to sales data through built-in tools. " +
+        "Your available tools are: GetAllCustomers, GetAllOrders, GetCustomerOrders, GetDelayedOrders. " +
+        "IMPORTANT: Always call a tool to retrieve data before answering any question about customers or orders. " +
+        "NEVER ask the user to upload files, connect systems, or provide data — the data is already available via tools. " +
+        "When assessing customer risk, consider: customer tier (A = most critical), number of delayed orders, " +
+        "delay duration in days, and order value. Be concise and factual in your responses.";
 
     private readonly IConfiguration _configuration;
     private readonly ITokenAcquisition _tokenAcquisition;
@@ -66,14 +67,20 @@ public class SalesAssistantService
         try
         {
             var tools = await mcpClient.GetMcpToolsAsAIFunctionsAsync();
+
+            if (tools.Count == 0)
+                throw new InvalidOperationException(
+                    "No MCP tools were loaded from the server. Ensure the MCP server is running and reachable.");
+
             var wrappedClient = new ChatClientBuilder(chatClient).UseFunctionInvocation().Build();
 
             var chatOptions = ChatClientHelper.CreateChatOptions(tools.Cast<AITool>());
 
-            // Add system message at the start if this is the first turn
-            var messagesWithSystem = new List<ChatMessage>();
-            if (session.History.Count == 1)
-                messagesWithSystem.Add(new ChatMessage(ChatRole.System, SystemPrompt));
+            // Always prepend the system message so it's present every turn
+            var messagesWithSystem = new List<ChatMessage>
+            {
+                new(ChatRole.System, SystemPrompt)
+            };
             messagesWithSystem.AddRange(session.History);
 
             var response = await wrappedClient.GetResponseAsync(messagesWithSystem, chatOptions);

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -15,7 +15,7 @@ public class SalesAssistantService
 {
     private const string SystemPrompt =
         "You are a Sales Assistant with direct access to sales data through built-in tools. " +
-        "Available tools: GetAllCustomers, GetAllOrders, GetCustomerOrders, GetDelayedOrders. " +
+        "Available tools: get_all_customers, get_all_orders, get_customer_orders, get_delayed_orders. " +
         "Use tools to retrieve data when needed, then answer concisely based on the results. " +
         "Do NOT ask the user to provide data or connect external systems — the data is already available. " +
         "Do NOT call the same tool more than once per response. " +
@@ -127,8 +127,9 @@ public class SalesAssistantService
         var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-        var serverUrl = _configuration["HttpMcpServerUrl"]
-            ?? throw new InvalidOperationException("HttpMcpServerUrl is not configured.");
+        var serverUrl = _configuration["SalesMcpServerUrl"]
+            ?? _configuration["HttpMcpServerUrl"]
+            ?? throw new InvalidOperationException("SalesMcpServerUrl / HttpMcpServerUrl is not configured.");
 
         return new HttpClientTransport(new HttpClientTransportOptions
         {
@@ -140,8 +141,8 @@ public class SalesAssistantService
 
     private static async Task<(List<SalesCustomerView>, List<SalesOrderView>)> RefreshContextAsync(IList<AIFunction> tools)
     {
-        var customerTool = tools.FirstOrDefault(t => t.Name == "GetAllCustomers");
-        var orderTool = tools.FirstOrDefault(t => t.Name == "GetAllOrders");
+        var customerTool = tools.FirstOrDefault(t => t.Name == "get_all_customers");
+        var orderTool = tools.FirstOrDefault(t => t.Name == "get_all_orders");
 
         List<SalesCustomerView> customers = [];
         List<SalesOrderView> orders = [];

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -1,0 +1,224 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using ClientLibrary;
+using McpWebClient.AiServices.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Web;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace McpWebClient.AiServices;
+
+public class SalesAssistantService
+{
+    private const string SystemPrompt =
+        "You are a Sales Copilot for a CRM/ERP system. " +
+        "Help the user analyze customer orders, identify delivery delays, and assess customer risk. " +
+        "Use the available tools to retrieve customer and order data. " +
+        "When assessing risk, consider: customer tier (A is most critical), number of delayed orders, " +
+        "delay duration, and order value. Be concise and actionable in your responses.";
+
+    private readonly IConfiguration _configuration;
+    private readonly ITokenAcquisition _tokenAcquisition;
+
+    private static readonly ConcurrentDictionary<string, SalesSession> _sessions = new();
+
+    public SalesAssistantService(IConfiguration configuration, ITokenAcquisition tokenAcquisition)
+    {
+        _configuration = configuration;
+        _tokenAcquisition = tokenAcquisition;
+    }
+
+    public async Task<SalesResponse> BeginAsync(string userKey, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    {
+        var session = new SalesSession();
+        _sessions[userKey] = session;
+        return await ChatAsync(session, prompt, mode, clientFactory);
+    }
+
+    public async Task<SalesResponse> ContinueAsync(string userKey, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    {
+        if (!_sessions.TryGetValue(userKey, out var session))
+        {
+            session = new SalesSession();
+            _sessions[userKey] = session;
+        }
+        return await ChatAsync(session, prompt, mode, clientFactory);
+    }
+
+    public void Clear(string userKey) => _sessions.TryRemove(userKey, out _);
+
+    // -------------------------------------------------------------------------
+
+    private async Task<SalesResponse> ChatAsync(SalesSession session, string prompt, FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    {
+        if (mode == FunctionCallingMode.Local)
+            throw new InvalidOperationException("Sales Assistant requires an MCP server connection (Unsecure or Secure mode).");
+
+        session.History.Add(new ChatMessage(ChatRole.User, prompt));
+
+        var (chatClient, mcpClient) = await CreateClientsAsync(mode, clientFactory);
+        List<SalesCustomerView> customers = [];
+        List<SalesOrderView> orders = [];
+
+        try
+        {
+            var tools = await mcpClient.GetMcpToolsAsAIFunctionsAsync();
+            var wrappedClient = new ChatClientBuilder(chatClient).UseFunctionInvocation().Build();
+
+            var chatOptions = ChatClientHelper.CreateChatOptions(tools.Cast<AITool>());
+
+            // Add system message at the start if this is the first turn
+            var messagesWithSystem = new List<ChatMessage>();
+            if (session.History.Count == 1)
+                messagesWithSystem.Add(new ChatMessage(ChatRole.System, SystemPrompt));
+            messagesWithSystem.AddRange(session.History);
+
+            var response = await wrappedClient.GetResponseAsync(messagesWithSystem, chatOptions);
+            var finalAnswer = response.Messages.LastOrDefault(m => m.Role == ChatRole.Assistant)?.Text;
+
+            // Append assistant messages to session history
+            foreach (var msg in response.Messages)
+            {
+                if (msg.Role == ChatRole.Assistant || msg.Role == ChatRole.Tool)
+                    session.History.Add(msg);
+            }
+
+            // Refresh context data after the AI turn
+            (customers, orders) = await RefreshContextAsync(mcpClient);
+
+            var chatHistory = BuildChatHistory(session.History);
+            return new SalesResponse(finalAnswer, chatHistory, customers, orders);
+        }
+        finally
+        {
+            await mcpClient.DisposeAsync();
+        }
+    }
+
+    private async Task<(IChatClient, McpClient)> CreateClientsAsync(FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    {
+        var config = new ConfigurationBuilder()
+            .AddUserSecrets<Program>()
+            .AddEnvironmentVariables()
+            .Build();
+
+        var chatClient = ChatClientHelper.GetChatClient(config);
+        var transport = await CreateTransportAsync(mode, clientFactory);
+        var mcpClient = await McpClient.CreateAsync(transport);
+        return (chatClient, mcpClient);
+    }
+
+    private async Task<IClientTransport> CreateTransportAsync(FunctionCallingMode mode, IHttpClientFactory clientFactory)
+    {
+        var httpClient = clientFactory.CreateClient();
+
+        if (mode == FunctionCallingMode.McpSecure)
+        {
+            var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        }
+
+        var serverUrl = _configuration["HttpMcpServerUrl"]
+            ?? throw new InvalidOperationException("HttpMcpServerUrl is not configured.");
+
+        return new HttpClientTransport(new HttpClientTransportOptions
+        {
+            Endpoint = new Uri(serverUrl),
+            Name = mode == FunctionCallingMode.McpSecure ? "Secure Sales Client" : "Unsecure Sales Client",
+            TransportMode = HttpTransportMode.StreamableHttp,
+        }, httpClient, NullLoggerFactory.Instance, ownsHttpClient: false);
+    }
+
+    private static async Task<(List<SalesCustomerView>, List<SalesOrderView>)> RefreshContextAsync(McpClient mcpClient)
+    {
+        var tools = await mcpClient.GetMcpToolsAsAIFunctionsAsync();
+
+        var customerTool = tools.FirstOrDefault(t => t.Name == "GetAllCustomers");
+        var orderTool = tools.FirstOrDefault(t => t.Name == "GetAllOrders");
+
+        List<SalesCustomerView> customers = [];
+        List<SalesOrderView> orders = [];
+
+        if (customerTool != null)
+        {
+            var result = await customerTool.InvokeAsync(null);
+            customers = DeserializeCustomers(result?.ToString());
+        }
+
+        if (orderTool != null)
+        {
+            var result = await orderTool.InvokeAsync(null);
+            orders = DeserializeOrders(result?.ToString());
+        }
+
+        return (customers, orders);
+    }
+
+    private static List<SalesCustomerView> DeserializeCustomers(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try
+        {
+            var raw = JsonSerializer.Deserialize<List<JsonElement>>(json);
+            if (raw == null) return [];
+            return raw.Select(e => new SalesCustomerView(
+                GetString(e, "id"),
+                GetString(e, "name"),
+                GetString(e, "industry"),
+                GetString(e, "tier"),
+                GetString(e, "accountManager")
+            )).ToList();
+        }
+        catch { return []; }
+    }
+
+    private static List<SalesOrderView> DeserializeOrders(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return [];
+        try
+        {
+            var raw = JsonSerializer.Deserialize<List<JsonElement>>(json);
+            if (raw == null) return [];
+            return raw.Select(e => new SalesOrderView(
+                GetString(e, "id"),
+                GetString(e, "customerId"),
+                GetString(e, "customerName"),
+                GetString(e, "productName"),
+                GetString(e, "status"),
+                GetDateTime(e, "orderDate"),
+                GetDateTime(e, "promisedDeliveryDate"),
+                GetNullableDateTime(e, "actualDeliveryDate"),
+                GetDecimal(e, "value")
+            )).ToList();
+        }
+        catch { return []; }
+    }
+
+    private static string GetString(JsonElement e, string prop) =>
+        e.TryGetProperty(prop, out var v) ? v.GetString() ?? string.Empty : string.Empty;
+
+    private static DateTime GetDateTime(JsonElement e, string prop) =>
+        e.TryGetProperty(prop, out var v) && v.TryGetDateTime(out var dt) ? dt : default;
+
+    private static DateTime? GetNullableDateTime(JsonElement e, string prop) =>
+        e.TryGetProperty(prop, out var v) && v.ValueKind != JsonValueKind.Null && v.TryGetDateTime(out var dt)
+            ? dt : null;
+
+    private static decimal GetDecimal(JsonElement e, string prop) =>
+        e.TryGetProperty(prop, out var v) && v.TryGetDecimal(out var d) ? d : 0m;
+
+    private static List<SalesChatMessage> BuildChatHistory(List<ChatMessage> history) =>
+        history
+            .Where(m => m.Role == ChatRole.User || m.Role == ChatRole.Assistant)
+            .Where(m => !string.IsNullOrWhiteSpace(m.Text))
+            .Select(m => new SalesChatMessage(m.Role == ChatRole.User ? "user" : "assistant", m.Text ?? string.Empty))
+            .ToList();
+
+    private class SalesSession
+    {
+        public List<ChatMessage> History { get; } = [];
+    }
+}

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -15,11 +15,11 @@ public class SalesAssistantService
 {
     private const string SystemPrompt =
         "You are a Sales Assistant with direct access to sales data through built-in tools. " +
-        "Your available tools are: GetAllCustomers, GetAllOrders, GetCustomerOrders, GetDelayedOrders. " +
-        "IMPORTANT: Always call a tool to retrieve data before answering any question about customers or orders. " +
-        "NEVER ask the user to upload files, connect systems, or provide data — the data is already available via tools. " +
-        "When assessing customer risk, consider: customer tier (A = most critical), number of delayed orders, " +
-        "delay duration in days, and order value. Be concise and factual in your responses.";
+        "Available tools: GetAllCustomers, GetAllOrders, GetCustomerOrders, GetDelayedOrders. " +
+        "Use tools to retrieve data when needed, then answer concisely based on the results. " +
+        "Do NOT ask the user to provide data or connect external systems — the data is already available. " +
+        "Do NOT call the same tool more than once per response. " +
+        "When assessing customer risk, consider: tier (A = most critical), delay count, delay duration, and order value.";
 
     private readonly IConfiguration _configuration;
     private readonly ITokenAcquisition _tokenAcquisition;
@@ -69,7 +69,9 @@ public class SalesAssistantService
                 throw new InvalidOperationException(
                     "No MCP tools were loaded from the server. Ensure the MCP server is running and reachable.");
 
-            var wrappedClient = new ChatClientBuilder(chatClient).UseFunctionInvocation().Build();
+            var wrappedClient = new ChatClientBuilder(chatClient)
+                .UseFunctionInvocation()
+                .Build();
 
             var chatOptions = ChatClientHelper.CreateChatOptions(tools.Cast<AITool>());
 
@@ -83,18 +85,21 @@ public class SalesAssistantService
             var response = await wrappedClient.GetResponseAsync(messagesWithSystem, chatOptions);
             var finalAnswer = response.Messages.LastOrDefault(m => m.Role == ChatRole.Assistant)?.Text;
 
-            // Append assistant messages to session history
+            // Extract MCP tool calls made during this turn for display
+            var toolCalls = ExtractToolCalls(response.Messages);
+
+            // Append assistant/tool messages to session history for multi-turn context
             foreach (var msg in response.Messages)
             {
                 if (msg.Role == ChatRole.Assistant || msg.Role == ChatRole.Tool)
                     session.History.Add(msg);
             }
 
-            // Refresh context data after the AI turn
-            (customers, orders) = await RefreshContextAsync(mcpClient);
+            // Refresh context data after the AI turn (reuse already-fetched tools)
+            (customers, orders) = await RefreshContextAsync(tools);
 
             var chatHistory = BuildChatHistory(session.History);
-            return new SalesResponse(finalAnswer, chatHistory, customers, orders);
+            return new SalesResponse(finalAnswer, chatHistory, customers, orders, toolCalls);
         }
         finally
         {
@@ -133,10 +138,8 @@ public class SalesAssistantService
         }, httpClient, NullLoggerFactory.Instance, ownsHttpClient: false);
     }
 
-    private static async Task<(List<SalesCustomerView>, List<SalesOrderView>)> RefreshContextAsync(McpClient mcpClient)
+    private static async Task<(List<SalesCustomerView>, List<SalesOrderView>)> RefreshContextAsync(IList<AIFunction> tools)
     {
-        var tools = await mcpClient.GetMcpToolsAsAIFunctionsAsync();
-
         var customerTool = tools.FirstOrDefault(t => t.Name == "GetAllCustomers");
         var orderTool = tools.FirstOrDefault(t => t.Name == "GetAllOrders");
 
@@ -210,6 +213,39 @@ public class SalesAssistantService
 
     private static decimal GetDecimal(JsonElement e, string prop) =>
         e.TryGetProperty(prop, out var v) && v.TryGetDecimal(out var d) ? d : 0m;
+
+    private static List<McpToolCall> ExtractToolCalls(IEnumerable<ChatMessage> messages)
+    {
+        var calls = new Dictionary<string, (string Name, string? Args)>();
+        var results = new HashSet<string>();
+
+        foreach (var msg in messages)
+        {
+            foreach (var content in msg.Contents)
+            {
+                if (content is FunctionCallContent call)
+                {
+                    string? args = null;
+                    if (call.Arguments is { Count: > 0 })
+                    {
+                        try { args = JsonSerializer.Serialize(call.Arguments); }
+                        catch { /* ignore serialization errors */ }
+                    }
+                    calls[call.CallId] = (call.Name, args);
+                }
+                else if (content is FunctionResultContent result)
+                {
+                    results.Add(result.CallId);
+                }
+            }
+        }
+
+        return calls.Select(kv => new McpToolCall(
+            kv.Value.Name,
+            kv.Value.Args,
+            results.Contains(kv.Key)
+        )).ToList();
+    }
 
     private static List<SalesChatMessage> BuildChatHistory(List<ChatMessage> history) =>
         history

--- a/src/McpWebClient/AiServices/SalesAssistantService.cs
+++ b/src/McpWebClient/AiServices/SalesAssistantService.cs
@@ -124,7 +124,7 @@ public class SalesAssistantService
     {
         var httpClient = clientFactory.CreateClient();
 
-        var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpScope"]!]);
+        var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync([_configuration["McpSalesScope"]!]);
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
         var serverUrl = _configuration["SalesMcpServerUrl"]

--- a/src/McpWebClient/Pages/Index.cshtml.cs
+++ b/src/McpWebClient/Pages/Index.cshtml.cs
@@ -7,7 +7,7 @@ using Microsoft.Identity.Web;
 
 namespace McpWebClient.Pages;
 
-[AuthorizeForScopes(ScopeKeySection = "McpScope")]
+[AuthorizeForScopes(ScopeKeySection = "McpDemoScope")]
 public class IndexModel : PageModel
 {
     private readonly ILogger<IndexModel> _logger;
@@ -43,7 +43,7 @@ public class IndexModel : PageModel
 
     public IActionResult OnGet()
     {
-        // No special processing on GET – state is managed via post backs
+        // No special processing on GET ï¿½ state is managed via post backs
         return Page();
     }
 

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml
@@ -7,6 +7,7 @@
     var customers = Model.SalesData?.Customers ?? [];
     var orders = Model.SalesData?.Orders ?? [];
     var chatHistory = Model.SalesData?.ChatHistory ?? [];
+    var toolCalls = Model.SalesData?.ToolCalls ?? [];
 }
 
 <div class="row g-3">
@@ -148,6 +149,48 @@
         </div>
     </div>
 
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     MCP Tool Calls – full-width row below both panels
+     ═══════════════════════════════════════════════════════════════════════ -->
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold">
+                🔧 MCP Tool Calls
+                <span class="badge bg-secondary ms-2 fw-normal">auto-approved</span>
+            </div>
+            <div class="card-body py-2">
+                @if (!toolCalls.Any())
+                {
+                    <p class="text-muted fst-italic small mb-0">Tool calls will appear here after each interaction.</p>
+                }
+                else
+                {
+                    <div class="d-flex flex-wrap gap-2">
+                        @foreach (var call in toolCalls)
+                        {
+                            <div class="border rounded px-3 py-2 bg-light d-flex align-items-start gap-2" style="min-width:180px;">
+                                <span class="mt-1">@(call.Success ? "✅" : "❌")</span>
+                                <div>
+                                    <div class="fw-semibold small">@call.ToolName</div>
+                                    @if (!string.IsNullOrWhiteSpace(call.Arguments))
+                                    {
+                                        <code class="text-muted" style="font-size:0.72rem;">@call.Arguments</code>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted" style="font-size:0.72rem;">no arguments</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
 </div>
 
 @section Scripts {

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml
@@ -63,14 +63,6 @@
                     <input type="hidden" name="IsNewConversation" value="@(chatHistory.Any() ? "false" : "true")" />
 
                     <div class="mb-2">
-                        <label class="form-label small fw-semibold mb-1">MCP Mode</label>
-                        <select class="form-select form-select-sm" name="SelectedMode" asp-for="SelectedMode">
-                            <option value="McpUnsecure">Unauthenticated MCP</option>
-                            <option value="McpSecure">Confidential OIDC MCP</option>
-                        </select>
-                    </div>
-
-                    <div class="mb-2">
                         <textarea class="form-control" rows="3" name="Prompt"
                                   placeholder="Ask a question about customers or orders…"
                                   asp-for="Prompt"></textarea>

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml
@@ -1,0 +1,167 @@
+@page
+@model SalesAssistantModel
+@using McpWebClient.AiServices.Models
+@{
+    ViewData["Title"] = "Sales Assistant";
+    var hasData = Model.SalesData != null;
+    var customers = Model.SalesData?.Customers ?? [];
+    var orders = Model.SalesData?.Orders ?? [];
+    var chatHistory = Model.SalesData?.ChatHistory ?? [];
+}
+
+<div class="row g-3">
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         LEFT – Chat Panel
+         ═══════════════════════════════════════════════════════════════════════ -->
+    <div class="col-md-6">
+        <div class="card h-100 shadow-sm">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span class="fw-semibold">💬 Sales Copilot</span>
+                <form method="post" asp-page-handler="Clear" class="mb-0">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </form>
+            </div>
+            <div class="card-body d-flex flex-column" style="min-height:520px;">
+
+                @* Conversation history *@
+                <div id="chat-history" class="flex-grow-1 overflow-auto mb-3 pe-1" style="max-height:380px;">
+                    @if (!chatHistory.Any())
+                    {
+                        <p class="text-muted fst-italic small">
+                            Start by asking something like:<br />
+                            • "Show me delayed orders"<br />
+                            • "Which customers are at risk?"<br />
+                            • "Tell me about Fabrikam GmbH"
+                        </p>
+                    }
+                    @foreach (var msg in chatHistory)
+                    {
+                        if (msg.Role == "user")
+                        {
+                            <div class="d-flex justify-content-end mb-2">
+                                <div class="bg-primary text-white rounded px-3 py-2" style="max-width:85%; white-space:pre-wrap;">@msg.Content</div>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="d-flex justify-content-start mb-2">
+                                <div class="bg-light border rounded px-3 py-2" style="max-width:85%; white-space:pre-wrap;">@msg.Content</div>
+                            </div>
+                        }
+                    }
+                </div>
+
+                @* Error *@
+                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <div class="alert alert-danger small py-2">@Model.ErrorMessage</div>
+                }
+
+                @* Input form *@
+                <form method="post" class="mt-auto">
+                    <input type="hidden" name="IsNewConversation" value="@(chatHistory.Any() ? "false" : "true")" />
+
+                    <div class="mb-2">
+                        <label class="form-label small fw-semibold mb-1">MCP Mode</label>
+                        <select class="form-select form-select-sm" name="SelectedMode" asp-for="SelectedMode">
+                            <option value="McpUnsecure">Unauthenticated MCP</option>
+                            <option value="McpSecure">Confidential OIDC MCP</option>
+                        </select>
+                    </div>
+
+                    <div class="mb-2">
+                        <textarea class="form-control" rows="3" name="Prompt"
+                                  placeholder="Ask a question about customers or orders…"
+                                  asp-for="Prompt"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Send</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         RIGHT – Context Panel
+         ═══════════════════════════════════════════════════════════════════════ -->
+    <div class="col-md-6">
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold">📊 Customer & Order Context</div>
+            <div class="card-body" style="max-height:600px; overflow-y:auto;">
+                @if (!hasData)
+                {
+                    <p class="text-muted fst-italic small">Context data will appear here after the first message.</p>
+                }
+                else if (!customers.Any())
+                {
+                    <p class="text-muted small">No customer data available.</p>
+                }
+                else
+                {
+                    @foreach (var customer in customers)
+                    {
+                        var customerOrders = orders.Where(o => o.CustomerId == customer.Id).ToList();
+                        var tierColor = customer.Tier switch { "A" => "primary", "B" => "secondary", _ => "light" };
+                        var tierTextColor = customer.Tier == "C" ? "text-dark" : "text-white";
+
+                        <div class="card mb-3 border">
+                            <div class="card-header py-2 d-flex justify-content-between align-items-center">
+                                <div>
+                                    <span class="fw-semibold">@customer.Name</span>
+                                    <small class="text-muted ms-2">@customer.Industry</small>
+                                </div>
+                                <span class="badge bg-@tierColor @tierTextColor">Tier @customer.Tier</span>
+                            </div>
+                            @if (customerOrders.Any())
+                            {
+                                <ul class="list-group list-group-flush">
+                                    @foreach (var order in customerOrders)
+                                    {
+                                        var (statusBadge, statusIcon) = order.Status switch
+                                        {
+                                            "Delayed"    => ("danger",  "🔴"),
+                                            "InProgress" => ("warning", "🟡"),
+                                            _            => ("success", "🟢")
+                                        };
+                                        var delayInfo = string.Empty;
+                                        if (order.Status == "Delayed" && order.ActualDeliveryDate.HasValue)
+                                        {
+                                            var days = (int)(order.ActualDeliveryDate.Value - order.PromisedDeliveryDate).TotalDays;
+                                            delayInfo = $" (+{days}d late)";
+                                        }
+
+                                        <li class="list-group-item py-2 d-flex justify-content-between align-items-start">
+                                            <div>
+                                                <div class="small fw-semibold">@order.ProductName</div>
+                                                <div class="text-muted" style="font-size:0.75rem;">
+                                                    Due: @order.PromisedDeliveryDate.ToString("yyyy-MM-dd")@delayInfo
+                                                    &nbsp;|&nbsp; CHF @order.Value.ToString("N0")
+                                                </div>
+                                            </div>
+                                            <span class="badge bg-@statusBadge ms-2">@statusIcon @order.Status</span>
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                            else
+                            {
+                                <div class="card-body py-2">
+                                    <small class="text-muted">No orders on record.</small>
+                                </div>
+                            }
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+
+</div>
+
+@section Scripts {
+    <script>
+        // Auto-scroll chat history to bottom after page load
+        const chatHistory = document.getElementById('chat-history');
+        if (chatHistory) chatHistory.scrollTop = chatHistory.scrollHeight;
+    </script>
+}

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml
@@ -94,7 +94,8 @@
                     @foreach (var customer in customers)
                     {
                         var customerOrders = orders.Where(o => o.CustomerId == customer.Id).ToList();
-                        var tierColor = customer.Tier switch { "A" => "primary", "B" => "secondary", _ => "light" };
+                        var hasTier = !string.IsNullOrWhiteSpace(customer.Tier);
+                        var tierColor = customer.Tier switch { "A" => "primary", "B" => "secondary", "C" => "light", _ => "light" };
                         var tierTextColor = customer.Tier == "C" ? "text-dark" : "text-white";
 
                         <div class="card mb-3 border">
@@ -103,7 +104,10 @@
                                     <span class="fw-semibold">@customer.Name</span>
                                     <small class="text-muted ms-2">@customer.Industry</small>
                                 </div>
-                                <span class="badge bg-@tierColor @tierTextColor">Tier @customer.Tier</span>
+                                @if (hasTier)
+                                {
+                                    <span class="badge bg-@tierColor @tierTextColor">Tier @customer.Tier</span>
+                                }
                             </div>
                             @if (customerOrders.Any())
                             {

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
@@ -7,7 +7,7 @@ using Microsoft.Identity.Web;
 
 namespace McpWebClient.Pages;
 
-[AuthorizeForScopes(ScopeKeySection = "McpScope")]
+[AuthorizeForScopes(ScopeKeySection = "McpSalesScope")]
 public class SalesAssistantModel : PageModel
 {
     private readonly SalesAssistantService _salesService;

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
@@ -17,9 +17,6 @@ public class SalesAssistantModel : PageModel
     public string Prompt { get; set; } = string.Empty;
 
     [BindProperty]
-    public FunctionCallingMode SelectedMode { get; set; } = FunctionCallingMode.McpUnsecure;
-
-    [BindProperty]
     public bool IsNewConversation { get; set; } = true;
 
     public SalesResponse? SalesData { get; private set; }
@@ -42,8 +39,8 @@ public class SalesAssistantModel : PageModel
         {
             var userKey = GetUserKey();
             SalesData = IsNewConversation
-                ? await _salesService.BeginAsync(userKey, Prompt, SelectedMode, _clientFactory)
-                : await _salesService.ContinueAsync(userKey, Prompt, SelectedMode, _clientFactory);
+                ? await _salesService.BeginAsync(userKey, Prompt, _clientFactory)
+                : await _salesService.ContinueAsync(userKey, Prompt, _clientFactory);
 
             IsNewConversation = false;
         }

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using McpWebClient.AiServices;
+using McpWebClient.AiServices.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Identity.Web;
+
+namespace McpWebClient.Pages;
+
+[AuthorizeForScopes(ScopeKeySection = "McpScope")]
+public class SalesAssistantModel : PageModel
+{
+    private readonly SalesAssistantService _salesService;
+    private readonly IHttpClientFactory _clientFactory;
+
+    [BindProperty]
+    public string Prompt { get; set; } = string.Empty;
+
+    [BindProperty]
+    public FunctionCallingMode SelectedMode { get; set; } = FunctionCallingMode.McpUnsecure;
+
+    [BindProperty]
+    public bool IsNewConversation { get; set; } = true;
+
+    public SalesResponse? SalesData { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public SalesAssistantModel(SalesAssistantService salesService, IHttpClientFactory clientFactory)
+    {
+        _salesService = salesService;
+        _clientFactory = clientFactory;
+    }
+
+    public IActionResult OnGet() => Page();
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Prompt))
+            return Page();
+
+        try
+        {
+            var userKey = GetUserKey();
+            SalesData = IsNewConversation
+                ? await _salesService.BeginAsync(userKey, Prompt, SelectedMode, _clientFactory)
+                : await _salesService.ContinueAsync(userKey, Prompt, SelectedMode, _clientFactory);
+
+            IsNewConversation = false;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+
+        return Page();
+    }
+
+    public IActionResult OnPostClear()
+    {
+        _salesService.Clear(GetUserKey());
+        return RedirectToPage();
+    }
+
+    private string GetUserKey() =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name ?? "anonymous";
+}

--- a/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
+++ b/src/McpWebClient/Pages/SalesAssistant.cshtml.cs
@@ -44,6 +44,11 @@ public class SalesAssistantModel : PageModel
 
             IsNewConversation = false;
         }
+        catch (MicrosoftIdentityWebChallengeUserException)
+        {
+            // Let Microsoft.Identity.Web handle incremental consent challenges.
+            throw;
+        }
         catch (Exception ex)
         {
             ErrorMessage = ex.Message;

--- a/src/McpWebClient/Pages/Shared/_Layout.cshtml
+++ b/src/McpWebClient/Pages/Shared/_Layout.cshtml
@@ -23,6 +23,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/SalesAssistant">Sales Assistant</a>
+                        </li>
                     </ul>
                     <partial name="_LoginPartial" />
                 </div>

--- a/src/McpWebClient/Pages/Shared/_Layout.cshtml
+++ b/src/McpWebClient/Pages/Shared/_Layout.cshtml
@@ -40,7 +40,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2025 - LLM using MCP server
+            &copy; 2026 - LLM using MCP server
         </div>
     </footer>
 

--- a/src/McpWebClient/Program.cs
+++ b/src/McpWebClient/Program.cs
@@ -20,7 +20,10 @@ public class Program
 
         builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
             .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"))
-            .EnableTokenAcquisitionToCallDownstreamApi([builder.Configuration["McpScope"]!])
+            .EnableTokenAcquisitionToCallDownstreamApi([
+                builder.Configuration["McpSalesScope"]!,
+                builder.Configuration["McpDemoScope"]!
+            ])
             .AddInMemoryTokenCaches();
 
         builder.Services.AddAuthorization(options =>

--- a/src/McpWebClient/Program.cs
+++ b/src/McpWebClient/Program.cs
@@ -34,6 +34,7 @@ public class Program
         builder.Services.AddRazorPages()
             .AddMicrosoftIdentityUI();
 
+        builder.Services.AddMemoryCache();
         builder.Services.AddSignalR();
         builder.Services.AddSingleton<ElicitationCoordinator>();
         builder.Services.AddScoped<ChatService>();

--- a/src/McpWebClient/Program.cs
+++ b/src/McpWebClient/Program.cs
@@ -1,3 +1,4 @@
+using McpWebClient.AiServices;
 using McpWebClient.AiServices.Elicitation;
 using McpWebClient.Hubs;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -33,6 +34,7 @@ public class Program
         builder.Services.AddSignalR();
         builder.Services.AddSingleton<ElicitationCoordinator>();
         builder.Services.AddScoped<ChatService>();
+        builder.Services.AddScoped<SalesAssistantService>();
 
         var app = builder.Build();
 

--- a/src/McpWebClient/Properties/launchSettings.json
+++ b/src/McpWebClient/Properties/launchSettings.json
@@ -7,7 +7,8 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_SYSTEM_NET_DISABLEIPV6": "1"
       }
     }
   }

--- a/src/McpWebClient/appsettings.Development.json
+++ b/src/McpWebClient/appsettings.Development.json
@@ -1,5 +1,7 @@
 {
   "DetailedErrors": true,
+  "HttpMcpServerUrl": "https://localhost:7133/mcp",
+  "SalesMcpServerUrl": "https://localhost:7133/mcp",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -1,7 +1,7 @@
 {
   "HttpMcpServerUrl": "https://localhost:7133/mcp",
   // Sales Assistant uses the local secure server (has SalesTools); switch to Azure URL after deployment
-  "SalesMcpServerUrl": "https://localhost:7133/mcp/sales",
+  "SalesMcpServerUrl": "https://localhost:7133/mcp",
   "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
   "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
   "AzureAd": {

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -1,6 +1,6 @@
 {
-  "HttpMcpServerUrl": "https://localhost:7133/mcp",
-  "SalesMcpServerUrl": "https://localhost:7133/mcp",
+  "HttpMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net/mcp",
+  "SalesMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net/mcp",
   "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
   "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
   "AzureAd": {

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -1,6 +1,5 @@
 {
-  //"HttpMcpServerUrl": "https://localhost:7133/mcp",
-  "HttpMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net/mcp",
+  "HttpMcpServerUrl": "https://localhost:7133/mcp",
   // Sales Assistant uses the local secure server (has SalesTools); switch to Azure URL after deployment
   "SalesMcpServerUrl": "https://localhost:7133/mcp/sales",
   "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -2,8 +2,9 @@
   //"HttpMcpServerUrl": "https://localhost:7133/mcp",
   "HttpMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net/mcp",
   // Sales Assistant uses the local secure server (has SalesTools); switch to Azure URL after deployment
-  "SalesMcpServerUrl": "https://localhost:7133/mcp",
-  "McpScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:tools",
+  "SalesMcpServerUrl": "https://localhost:7133/mcp/sales",
+  "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
+  "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
     "Domain": "cedricmendelingmail.onmicrosoft.com",
@@ -15,7 +16,8 @@
   // Deployment Damien
   //"HttpMcpServerUrl": "https://localhost:7133/mcp",
   ////"HttpMcpServerUrl": "https://mcpoauthsecurity-hag0drckepathyb6.westeurope-01.azurewebsites.net/mcp",
-  //"McpScope": "api://96b0f495-3b65-4c8f-a0c6-c3767c3365ed/mcp:tools",
+  //"McpSalesScope": "api://96b0f495-3b65-4c8f-a0c6-c3767c3365ed/mcp:sales",
+  //"McpDemoScope": "api://96b0f495-3b65-4c8f-a0c6-c3767c3365ed/mcp:demo",
   //"AzureAd": {
   //  "Instance": "https://login.microsoftonline.com/",
   //  "Domain": "damienbodsharepoint.onmicrosoft.com",
@@ -32,5 +34,3 @@
   },
   "AllowedHosts": "*"
 }
-
-

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -1,6 +1,5 @@
 {
   "HttpMcpServerUrl": "https://localhost:7133/mcp",
-  // Sales Assistant uses the local secure server (has SalesTools); switch to Azure URL after deployment
   "SalesMcpServerUrl": "https://localhost:7133/mcp",
   "McpSalesScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:sales",
   "McpDemoScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:demo",
@@ -13,8 +12,8 @@
   },
 
   // Deployment Damien
-  //"HttpMcpServerUrl": "https://localhost:7133/mcp",
-  ////"HttpMcpServerUrl": "https://mcpoauthsecurity-hag0drckepathyb6.westeurope-01.azurewebsites.net/mcp",
+  //"HttpMcpServerUrl": "https://mcpoauthsecurity-hag0drckepathyb6.westeurope-01.azurewebsites.net/mcp",
+  //"SalesMcpServerUrl": "https://mcpoauthsecurity-hag0drckepathyb6.westeurope-01.azurewebsites.net/mcp",
   //"McpSalesScope": "api://96b0f495-3b65-4c8f-a0c6-c3767c3365ed/mcp:sales",
   //"McpDemoScope": "api://96b0f495-3b65-4c8f-a0c6-c3767c3365ed/mcp:demo",
   //"AzureAd": {

--- a/src/McpWebClient/appsettings.json
+++ b/src/McpWebClient/appsettings.json
@@ -1,6 +1,8 @@
 {
   //"HttpMcpServerUrl": "https://localhost:7133/mcp",
   "HttpMcpServerUrl": "https://mvp-playground-mcp-a0dsayfkcpcng5f0.switzerlandnorth-01.azurewebsites.net/mcp",
+  // Sales Assistant uses the local secure server (has SalesTools); switch to Azure URL after deployment
+  "SalesMcpServerUrl": "https://localhost:7133/mcp",
   "McpScope": "api://943fc68f-03d5-461a-b1b3-1395101875d8/mcp:tools",
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/src/ToolsLibrary/Data/SalesDataStore.cs
+++ b/src/ToolsLibrary/Data/SalesDataStore.cs
@@ -1,0 +1,141 @@
+using ToolsLibrary.Models;
+
+namespace ToolsLibrary.Data;
+
+public class SalesDataStore
+{
+    private readonly List<Customer> _customers;
+    private readonly List<Order> _orders;
+
+    public SalesDataStore()
+    {
+        _customers = SeedCustomers();
+        _orders = SeedOrders();
+    }
+
+    public IReadOnlyList<Customer> GetAllCustomers() => _customers.AsReadOnly();
+
+    public IReadOnlyList<Order> GetAllOrders() => _orders.AsReadOnly();
+
+    public IReadOnlyList<Order> GetOrdersByCustomer(string customerId) =>
+        _orders.Where(o => o.CustomerId == customerId).ToList().AsReadOnly();
+
+    public IReadOnlyList<Order> GetDelayedOrders() =>
+        _orders.Where(o => o.Status == OrderStatus.Delayed).ToList().AsReadOnly();
+
+    public Customer? FindCustomer(string customerId) =>
+        _customers.FirstOrDefault(c => c.Id == customerId);
+
+    // -------------------------------------------------------------------------
+    // Seed data
+    // -------------------------------------------------------------------------
+
+    private static List<Customer> SeedCustomers() =>
+    [
+        new() { Id = "contoso-ag",           Name = "Contoso AG",            Industry = "Manufacturing", Tier = CustomerTier.A, AccountManager = "Anna Bauer",    Email = "orders@contoso.ch" },
+        new() { Id = "fabrikam-gmbh",        Name = "Fabrikam GmbH",         Industry = "Retail",        Tier = CustomerTier.A, AccountManager = "Marco Sutter",  Email = "orders@fabrikam.de" },
+        new() { Id = "alpine-bikes",         Name = "Alpine Bikes",          Industry = "Sports",        Tier = CustomerTier.B, AccountManager = "Sandra Klein",  Email = "orders@alpinebikes.ch" },
+        new() { Id = "helvetic-pharma",      Name = "Helvetic Pharma",       Industry = "Pharma",        Tier = CustomerTier.A, AccountManager = "David Meier",   Email = "orders@helveticpharma.ch" },
+        new() { Id = "swisstech-solutions",  Name = "SwissTech Solutions",   Industry = "IT",            Tier = CustomerTier.B, AccountManager = "Lisa Vogel",    Email = "orders@swisstech.ch" },
+        new() { Id = "local-shop-basel",     Name = "Local Shop Basel",      Industry = "Retail",        Tier = CustomerTier.C, AccountManager = "Hans Müller",   Email = "orders@localshop.ch" },
+    ];
+
+    private static List<Order> SeedOrders()
+    {
+        // Reference date: treat relative to a fixed anchor so data stays stable
+        var anchor = new DateTime(2025, 5, 1);
+
+        return
+        [
+            // ── Contoso AG – all OnTime ──────────────────────────────────────
+            new()
+            {
+                Id = "ORD-001", CustomerId = "contoso-ag", ProductName = "Industrial Sensors Batch A",
+                OrderDate = anchor.AddDays(-60), PromisedDeliveryDate = anchor.AddDays(-30),
+                ActualDeliveryDate = anchor.AddDays(-32), Status = OrderStatus.OnTime, Value = 18_500m
+            },
+            new()
+            {
+                Id = "ORD-002", CustomerId = "contoso-ag", ProductName = "Control Units v3",
+                OrderDate = anchor.AddDays(-45), PromisedDeliveryDate = anchor.AddDays(-15),
+                ActualDeliveryDate = anchor.AddDays(-16), Status = OrderStatus.OnTime, Value = 24_000m
+            },
+            new()
+            {
+                Id = "ORD-003", CustomerId = "contoso-ag", ProductName = "Assembly Tools Kit",
+                OrderDate = anchor.AddDays(-20), PromisedDeliveryDate = anchor.AddDays(10),
+                ActualDeliveryDate = anchor.AddDays(9),  Status = OrderStatus.OnTime, Value = 9_200m
+            },
+
+            // ── Fabrikam GmbH – all Delayed 5-10 days, high value ────────────
+            new()
+            {
+                Id = "ORD-004", CustomerId = "fabrikam-gmbh", ProductName = "Retail Display Units",
+                OrderDate = anchor.AddDays(-90), PromisedDeliveryDate = anchor.AddDays(-50),
+                ActualDeliveryDate = anchor.AddDays(-44), Status = OrderStatus.Delayed, Value = 42_000m
+            },
+            new()
+            {
+                Id = "ORD-005", CustomerId = "fabrikam-gmbh", ProductName = "POS Terminal Software Licenses",
+                OrderDate = anchor.AddDays(-60), PromisedDeliveryDate = anchor.AddDays(-20),
+                ActualDeliveryDate = anchor.AddDays(-12), Status = OrderStatus.Delayed, Value = 31_500m
+            },
+            new()
+            {
+                Id = "ORD-006", CustomerId = "fabrikam-gmbh", ProductName = "Warehouse Management System",
+                OrderDate = anchor.AddDays(-35), PromisedDeliveryDate = anchor.AddDays(5),
+                ActualDeliveryDate = anchor.AddDays(13), Status = OrderStatus.Delayed, Value = 67_000m
+            },
+
+            // ── Helvetic Pharma – 1 heavily delayed, 1 OnTime ───────────────
+            new()
+            {
+                Id = "ORD-007", CustomerId = "helvetic-pharma", ProductName = "Lab Equipment Set",
+                OrderDate = anchor.AddDays(-80), PromisedDeliveryDate = anchor.AddDays(-40),
+                ActualDeliveryDate = anchor.AddDays(-25), Status = OrderStatus.Delayed, Value = 55_000m
+            },
+            new()
+            {
+                Id = "ORD-008", CustomerId = "helvetic-pharma", ProductName = "Compliance Documentation Package",
+                OrderDate = anchor.AddDays(-30), PromisedDeliveryDate = anchor.AddDays(-5),
+                ActualDeliveryDate = anchor.AddDays(-6),  Status = OrderStatus.OnTime,  Value = 8_000m
+            },
+
+            // ── SwissTech Solutions – 2 delayed 2 days, 1 InProgress ─────────
+            new()
+            {
+                Id = "ORD-009", CustomerId = "swisstech-solutions", ProductName = "Cloud Infrastructure Setup",
+                OrderDate = anchor.AddDays(-50), PromisedDeliveryDate = anchor.AddDays(-20),
+                ActualDeliveryDate = anchor.AddDays(-18), Status = OrderStatus.Delayed, Value = 14_000m
+            },
+            new()
+            {
+                Id = "ORD-010", CustomerId = "swisstech-solutions", ProductName = "Security Audit Report",
+                OrderDate = anchor.AddDays(-40), PromisedDeliveryDate = anchor.AddDays(-10),
+                ActualDeliveryDate = anchor.AddDays(-8),  Status = OrderStatus.Delayed, Value = 11_000m
+            },
+            new()
+            {
+                Id = "ORD-011", CustomerId = "swisstech-solutions", ProductName = "DevOps Pipeline Implementation",
+                OrderDate = anchor.AddDays(-15), PromisedDeliveryDate = anchor.AddDays(20),
+                ActualDeliveryDate = null, Status = OrderStatus.InProgress, Value = 22_000m
+            },
+
+            // ── Alpine Bikes – 1 OnTime ──────────────────────────────────────
+            new()
+            {
+                Id = "ORD-012", CustomerId = "alpine-bikes", ProductName = "E-Bike Firmware Update",
+                OrderDate = anchor.AddDays(-25), PromisedDeliveryDate = anchor.AddDays(5),
+                ActualDeliveryDate = anchor.AddDays(4),  Status = OrderStatus.OnTime, Value = 6_500m
+            },
+
+            // ── Local Shop Basel – 1 Delayed, low value ─────────────────────
+            new()
+            {
+                Id = "ORD-013", CustomerId = "local-shop-basel", ProductName = "Point-of-Sale Labels",
+                OrderDate = anchor.AddDays(-20), PromisedDeliveryDate = anchor.AddDays(-5),
+                ActualDeliveryDate = anchor.AddDays(-1),  Status = OrderStatus.Delayed, Value = 850m
+            },
+        ];
+    }
+}

--- a/src/ToolsLibrary/Models/Customer.cs
+++ b/src/ToolsLibrary/Models/Customer.cs
@@ -1,0 +1,13 @@
+namespace ToolsLibrary.Models;
+
+public enum CustomerTier { A, B, C }
+
+public class Customer
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Industry { get; set; } = string.Empty;
+    public CustomerTier Tier { get; set; }
+    public string AccountManager { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}

--- a/src/ToolsLibrary/Models/Order.cs
+++ b/src/ToolsLibrary/Models/Order.cs
@@ -1,0 +1,15 @@
+namespace ToolsLibrary.Models;
+
+public enum OrderStatus { OnTime, Delayed, InProgress }
+
+public class Order
+{
+    public string Id { get; set; } = string.Empty;
+    public string CustomerId { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public DateTime OrderDate { get; set; }
+    public DateTime PromisedDeliveryDate { get; set; }
+    public DateTime? ActualDeliveryDate { get; set; }
+    public OrderStatus Status { get; set; }
+    public decimal Value { get; set; }
+}

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -7,7 +7,7 @@ using ToolsLibrary.Models;
 namespace ToolsLibrary.Tools;
 
 [McpServerToolType]
-public class SalesTools
+public class SalesTools(SalesDataStore store)
 {
     private static readonly JsonSerializerOptions _json = new()
     {
@@ -17,7 +17,7 @@ public class SalesTools
 
     [McpServerTool]
     [Description("Returns all customers with their Id, Name, Industry, Tier, AccountManager and Email.")]
-    public string GetAllCustomers(SalesDataStore store)
+    public string GetAllCustomers()
     {
         var customers = store.GetAllCustomers().Select(c => new
         {
@@ -30,7 +30,7 @@ public class SalesTools
 
     [McpServerTool]
     [Description("Returns all orders across all customers including status (OnTime, Delayed, InProgress), dates and value.")]
-    public string GetAllOrders(SalesDataStore store)
+    public string GetAllOrders()
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetAllOrders().Select(o => MapOrder(o, customers));
@@ -39,7 +39,7 @@ public class SalesTools
 
     [McpServerTool]
     [Description("Returns all orders for a specific customer by their customerId.")]
-    public string GetCustomerOrders(SalesDataStore store, [Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
+    public string GetCustomerOrders([Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetOrdersByCustomer(customerId).Select(o => MapOrder(o, customers));
@@ -48,7 +48,7 @@ public class SalesTools
 
     [McpServerTool]
     [Description("Returns only delayed orders. Includes how many days late each order is.")]
-    public string GetDelayedOrders(SalesDataStore store)
+    public string GetDelayedOrders()
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var delayed = store.GetDelayedOrders().Select(o =>

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using ToolsLibrary.Data;
+using ToolsLibrary.Models;
+
+namespace ToolsLibrary.Tools;
+
+[McpServerToolType]
+public class SalesTools(SalesDataStore store)
+{
+    private static readonly JsonSerializerOptions _json = new() { WriteIndented = true };
+
+    [McpServerTool]
+    [Description("Returns all customers with their Id, Name, Industry, Tier, AccountManager and Email.")]
+    public string GetAllCustomers()
+    {
+        var customers = store.GetAllCustomers().Select(c => new
+        {
+            c.Id, c.Name, c.Industry,
+            Tier = c.Tier.ToString(),
+            c.AccountManager, c.Email
+        });
+        return JsonSerializer.Serialize(customers, _json);
+    }
+
+    [McpServerTool]
+    [Description("Returns all orders across all customers including status (OnTime, Delayed, InProgress), dates and value.")]
+    public string GetAllOrders()
+    {
+        var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
+        var orders = store.GetAllOrders().Select(o => MapOrder(o, customers));
+        return JsonSerializer.Serialize(orders, _json);
+    }
+
+    [McpServerTool]
+    [Description("Returns all orders for a specific customer by their customerId.")]
+    public string GetCustomerOrders([Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
+    {
+        var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
+        var orders = store.GetOrdersByCustomer(customerId).Select(o => MapOrder(o, customers));
+        return JsonSerializer.Serialize(orders, _json);
+    }
+
+    [McpServerTool]
+    [Description("Returns only delayed orders. Includes how many days late each order is.")]
+    public string GetDelayedOrders()
+    {
+        var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
+        var delayed = store.GetDelayedOrders().Select(o =>
+        {
+            var mapped = MapOrder(o, customers);
+            var daysLate = o.ActualDeliveryDate.HasValue
+                ? (int)(o.ActualDeliveryDate.Value - o.PromisedDeliveryDate).TotalDays
+                : 0;
+            return new
+            {
+                mapped.Id, mapped.CustomerId, mapped.CustomerName, mapped.ProductName,
+                mapped.Status, mapped.OrderDate, mapped.PromisedDeliveryDate,
+                mapped.ActualDeliveryDate, mapped.Value,
+                DaysLate = daysLate
+            };
+        });
+        return JsonSerializer.Serialize(delayed, _json);
+    }
+
+    private static OrderView MapOrder(Order o, Dictionary<string, string> customerNames) => new(
+        o.Id,
+        o.CustomerId,
+        customerNames.GetValueOrDefault(o.CustomerId, "Unknown"),
+        o.ProductName,
+        o.Status.ToString(),
+        o.OrderDate,
+        o.PromisedDeliveryDate,
+        o.ActualDeliveryDate,
+        o.Value
+    );
+
+    private record OrderView(
+        string Id,
+        string CustomerId,
+        string CustomerName,
+        string ProductName,
+        string Status,
+        DateTime OrderDate,
+        DateTime PromisedDeliveryDate,
+        DateTime? ActualDeliveryDate,
+        decimal Value
+    );
+}

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -68,7 +68,7 @@ public class SalesTools(SalesDataStore store, IHttpContextAccessor httpContextAc
             var mapped = MapOrder(o, customers);
             var daysLate = o.ActualDeliveryDate.HasValue
                 ? (int)(o.ActualDeliveryDate.Value - o.PromisedDeliveryDate).TotalDays
-                : 0;
+                : Math.Max(0, (int)(DateTime.UtcNow.Date - o.PromisedDeliveryDate.Date).TotalDays);
             return new
             {
                 mapped.Id, mapped.CustomerId, mapped.CustomerName, mapped.ProductName,

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using System.Security.Claims;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 using ToolsLibrary.Data;
 using ToolsLibrary.Models;
@@ -7,7 +9,7 @@ using ToolsLibrary.Models;
 namespace ToolsLibrary.Tools;
 
 [McpServerToolType]
-public class SalesTools(SalesDataStore store)
+public class SalesTools(SalesDataStore store, IHttpContextAccessor httpContextAccessor)
 {
     private static readonly JsonSerializerOptions _json = new()
     {
@@ -19,6 +21,7 @@ public class SalesTools(SalesDataStore store)
     [Description("Returns all customers with their Id, Name, Industry, Tier, AccountManager and Email.")]
     public string GetAllCustomers()
     {
+        EnsureSalesScope();
         var customers = store.GetAllCustomers().Select(c => new
         {
             c.Id, c.Name, c.Industry,
@@ -32,6 +35,7 @@ public class SalesTools(SalesDataStore store)
     [Description("Returns all orders across all customers including status (OnTime, Delayed, InProgress), dates and value.")]
     public string GetAllOrders()
     {
+        EnsureSalesScope();
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetAllOrders().Select(o => MapOrder(o, customers));
         return JsonSerializer.Serialize(orders, _json);
@@ -41,6 +45,7 @@ public class SalesTools(SalesDataStore store)
     [Description("Returns all orders for a specific customer by their customerId.")]
     public string GetCustomerOrders([Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
     {
+        EnsureSalesScope();
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetOrdersByCustomer(customerId).Select(o => MapOrder(o, customers));
         return JsonSerializer.Serialize(orders, _json);
@@ -51,6 +56,7 @@ public class SalesTools(SalesDataStore store)
     public string GetDelayedOrders(
         [Description("Optional customer ID to filter delayed orders for a specific customer.")] string? customerId = null)
     {
+        EnsureSalesScope();
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var delayedOrders = store.GetDelayedOrders();
         if (!string.IsNullOrEmpty(customerId))
@@ -72,6 +78,32 @@ public class SalesTools(SalesDataStore store)
             };
         });
         return JsonSerializer.Serialize(delayed, _json);
+    }
+
+    private void EnsureSalesScope()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (!HasScope(user, "mcp:sales"))
+        {
+            throw new UnauthorizedAccessException("The mcp:sales scope is required to call sales tools.");
+        }
+    }
+
+    private static bool HasScope(ClaimsPrincipal? user, string requiredScope)
+    {
+        if (user is null)
+        {
+            return false;
+        }
+
+        var scopeClaimValues = user
+            .FindAll("http://schemas.microsoft.com/identity/claims/scope")
+            .Select(c => c.Value)
+            .Concat(user.FindAll("scp").Select(c => c.Value));
+
+        return scopeClaimValues
+            .SelectMany(v => v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .Any(s => string.Equals(s, requiredScope, StringComparison.Ordinal));
     }
 
     private static OrderView MapOrder(Order o, Dictionary<string, string> customerNames) => new(

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -7,7 +7,7 @@ using ToolsLibrary.Models;
 namespace ToolsLibrary.Tools;
 
 [McpServerToolType]
-public class SalesTools(SalesDataStore store)
+public class SalesTools
 {
     private static readonly JsonSerializerOptions _json = new()
     {
@@ -17,7 +17,7 @@ public class SalesTools(SalesDataStore store)
 
     [McpServerTool]
     [Description("Returns all customers with their Id, Name, Industry, Tier, AccountManager and Email.")]
-    public string GetAllCustomers()
+    public string GetAllCustomers(SalesDataStore store)
     {
         var customers = store.GetAllCustomers().Select(c => new
         {
@@ -30,7 +30,7 @@ public class SalesTools(SalesDataStore store)
 
     [McpServerTool]
     [Description("Returns all orders across all customers including status (OnTime, Delayed, InProgress), dates and value.")]
-    public string GetAllOrders()
+    public string GetAllOrders(SalesDataStore store)
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetAllOrders().Select(o => MapOrder(o, customers));
@@ -39,7 +39,7 @@ public class SalesTools(SalesDataStore store)
 
     [McpServerTool]
     [Description("Returns all orders for a specific customer by their customerId.")]
-    public string GetCustomerOrders([Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
+    public string GetCustomerOrders(SalesDataStore store, [Description("The customer Id, e.g. 'fabrikam-gmbh'")] string customerId)
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var orders = store.GetOrdersByCustomer(customerId).Select(o => MapOrder(o, customers));
@@ -48,7 +48,7 @@ public class SalesTools(SalesDataStore store)
 
     [McpServerTool]
     [Description("Returns only delayed orders. Includes how many days late each order is.")]
-    public string GetDelayedOrders()
+    public string GetDelayedOrders(SalesDataStore store)
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
         var delayed = store.GetDelayedOrders().Select(o =>

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -9,7 +9,11 @@ namespace ToolsLibrary.Tools;
 [McpServerToolType]
 public class SalesTools(SalesDataStore store)
 {
-    private static readonly JsonSerializerOptions _json = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     [McpServerTool]
     [Description("Returns all customers with their Id, Name, Industry, Tier, AccountManager and Email.")]

--- a/src/ToolsLibrary/Tools/SalesTools.cs
+++ b/src/ToolsLibrary/Tools/SalesTools.cs
@@ -47,11 +47,17 @@ public class SalesTools(SalesDataStore store)
     }
 
     [McpServerTool]
-    [Description("Returns only delayed orders. Includes how many days late each order is.")]
-    public string GetDelayedOrders()
+    [Description("Returns only delayed orders. Includes how many days late each order is. Optionally filters by customer ID.")]
+    public string GetDelayedOrders(
+        [Description("Optional customer ID to filter delayed orders for a specific customer.")] string? customerId = null)
     {
         var customers = store.GetAllCustomers().ToDictionary(c => c.Id, c => c.Name);
-        var delayed = store.GetDelayedOrders().Select(o =>
+        var delayedOrders = store.GetDelayedOrders();
+        if (!string.IsNullOrEmpty(customerId))
+        {
+            delayedOrders = delayedOrders.Where(o => o.CustomerId == customerId).ToList().AsReadOnly();
+        }
+        var delayed = delayedOrders.Select(o =>
         {
             var mapped = MapOrder(o, customers);
             var daysLate = o.ActualDeliveryDate.HasValue

--- a/src/ToolsLibrary/ToolsLibrary.csproj
+++ b/src/ToolsLibrary/ToolsLibrary.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>

--- a/src/UnsecureHttpMcpServer/Program.cs
+++ b/src/UnsecureHttpMcpServer/Program.cs
@@ -1,8 +1,11 @@
+using ToolsLibrary.Data;
 using ToolsLibrary.Prompts;
 using ToolsLibrary.Resources;
 using ToolsLibrary.Tools;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<SalesDataStore>();
 
 builder.Services
        .AddMcpServer()
@@ -14,7 +17,8 @@ builder.Services
        .WithResources<DocumentationResource>()
        .WithTools<RandomNumberTools>()
        .WithTools<SamplingTool>()
-       .WithTools<DateTools>();
+       .WithTools<DateTools>()
+       .WithTools<SalesTools>();
 
 // Add services to the container.
 var app = builder.Build();

--- a/src/UnsecureHttpMcpServer/Program.cs
+++ b/src/UnsecureHttpMcpServer/Program.cs
@@ -6,6 +6,7 @@ using ToolsLibrary.Tools;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<SalesDataStore>();
+builder.Services.AddTransient<SalesTools>();
 
 builder.Services
        .AddMcpServer()


### PR DESCRIPTION
## Why
This adds a dedicated Sales Assistant flow that can query MCP sales data directly, while tightening auth boundaries by splitting the old single `mcp:tools` scope into `mcp:sales` and `mcp:demo`.

## What changed
- Added a new Sales Assistant UI and backend service that uses MCP tools for customers/orders and keeps tool-call context visible in the response panel.
- Added a sales data model and `SalesTools` set (customers, orders, delayed orders), including optional `customerId` filtering on `get_delayed_orders`.
- Updated MCP server authorization to use separate policies and endpoints:
  - `/mcp/sales` requires `mcp:sales`
  - `/mcp` requires `mcp:demo`
- Updated web client token acquisition and page scope attributes so:
  - Sales Assistant requests `mcp:sales`
  - Demo/random-number flow requests `mcp:demo`
- Fixed scope-claim evaluation to handle both `scope`/`scp` claims and space-delimited values.
- Fixed incremental consent behavior for sales scope by allowing challenge exceptions to propagate.

## Notes for reviewers
- `McpWebClient` is configured for local secure testing (`https://localhost:7133`) for the updated scopes.
- Azure AD scopes `mcp:sales` and `mcp:demo` are expected to exist in the API app registration.
- `UnsecureHttpMcpServer` has a small update included from the branch history as part of the sales demo work.