### PR TITLE
Add FunctionCalling page and MCP auth demo updates

### DIFF
--- a/src/ClientLibrary/ChatClientHelper.cs
+++ b/src/ClientLibrary/ChatClientHelper.cs
@@ -14,7 +14,7 @@ public static class ChatClientHelper
     /// Creates ChatOptions for the AI chat client
     /// </summary>
     /// <param name="tools">Optional tools/functions to make available</param>
-    /// <param name="toolMode">The tool mode to use (Auto, RequiredAny, None). Defaults to Auto.</param>
+    /// <param name="toolMode">The tool mode to use (Auto, None). Defaults to Auto.</param>
     public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null)
     {
         var options = new ChatOptions();

--- a/src/ClientLibrary/ChatClientHelper.cs
+++ b/src/ClientLibrary/ChatClientHelper.cs
@@ -14,8 +14,8 @@ public static class ChatClientHelper
     /// Creates ChatOptions for the AI chat client
     /// </summary>
     /// <param name="tools">Optional tools/functions to make available</param>
-    /// <param name="autoInvokeTools">Whether to auto-invoke tools or return them for manual processing</param>
-    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null)
+    /// <param name="toolMode">The tool mode to use (Auto, RequiredAny, None). Defaults to Auto.</param>
+    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null)
     {
         var options = new ChatOptions();
 
@@ -27,8 +27,7 @@ public static class ChatClientHelper
                 options.Tools.Add(tool);
             }
 
-            // Set tool mode - Auto means the model decides when to call tools
-            options.ToolMode = ChatToolMode.Auto;
+            options.ToolMode = toolMode ?? ChatToolMode.Auto;
 
         }
 

--- a/src/ClientLibrary/ChatClientHelper.cs
+++ b/src/ClientLibrary/ChatClientHelper.cs
@@ -15,16 +15,9 @@ public static class ChatClientHelper
     /// </summary>
     /// <param name="tools">Optional tools/functions to make available</param>
     /// <param name="toolMode">The tool mode to use (Auto, None). Defaults to Auto.</param>
-    /// <param name="temperature">Sampling temperature (0 = deterministic). Defaults to null (provider default).</param>
-    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null, float? temperature = null)
+    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null)
     {
         var options = new ChatOptions();
-
-        if (temperature.HasValue)
-        {
-            options.Temperature = temperature.Value;
-        }
-
         if (tools != null)
         {
             foreach (var tool in tools)

--- a/src/ClientLibrary/ChatClientHelper.cs
+++ b/src/ClientLibrary/ChatClientHelper.cs
@@ -15,9 +15,15 @@ public static class ChatClientHelper
     /// </summary>
     /// <param name="tools">Optional tools/functions to make available</param>
     /// <param name="toolMode">The tool mode to use (Auto, None). Defaults to Auto.</param>
-    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null)
+    /// <param name="temperature">Sampling temperature (0 = deterministic). Defaults to null (provider default).</param>
+    public static ChatOptions CreateChatOptions(IEnumerable<AITool>? tools = null, ChatToolMode? toolMode = null, float? temperature = null)
     {
         var options = new ChatOptions();
+
+        if (temperature.HasValue)
+        {
+            options.Temperature = temperature.Value;
+        }
 
         if (tools != null)
         {

--- a/src/HttpMcpServer/Program.cs
+++ b/src/HttpMcpServer/Program.cs
@@ -32,16 +32,13 @@ builder.Services.AddSingleton<SalesDataStore>();
 builder.Services.AddTransient<SalesTools>();
 
 builder.Services
-       .AddMcpServer()
-    .WithHttpTransport(options =>
-    {
-        options.Stateless = true;
-    })
-       .WithPrompts<PromptExamples>()
-       .WithResources<DocumentationResource>()
-       .WithTools<RandomNumberTools>()
-       .WithTools<DateTools>()
-       .WithTools<SalesTools>();
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithPrompts<PromptExamples>()
+    .WithResources<DocumentationResource>()
+    .WithTools<RandomNumberTools>()
+    .WithTools<DateTools>()
+    .WithTools<SalesTools>();
 
 // Add CORS for HTTP transport support in browsers
 builder.Services.AddCors(options =>

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -92,8 +92,6 @@ public class ChatService
     {
         if (_initialized) return;
 
-
-
         if (_functionCallingMode == FunctionCallingMode.Local)
         {
             _tools = GetLocalTools();

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -43,7 +43,6 @@ public class ChatService
     private ApprovalMode _approvalMode = ApprovalMode.Auto;
     private FunctionCallingMode _functionCallingMode = FunctionCallingMode.Local;
     private ChatToolMode _toolMode = ChatToolMode.Auto;
-    private float? _temperature;
     private string? _systemPrompt;
     private readonly ITokenAcquisition _tokenAcquisition;
 
@@ -90,15 +89,6 @@ public class ChatService
         }
     }
 
-    public void SetTemperature(float? temperature)
-    {
-        if (_temperature != temperature)
-        {
-            _initialized = false;
-            _temperature = temperature;
-        }
-    }
-
     public void SetSystemPrompt(string? systemPrompt)
     {
         if (_systemPrompt != systemPrompt)
@@ -128,7 +118,7 @@ public class ChatService
             _chatClient = new ChatClientBuilder(_chatClient).UseFunctionInvocation().Build();
         }
 
-        _promptingService = new PromptingService(_chatClient, _tools, _toolMode, _temperature, _systemPrompt);
+        _promptingService = new PromptingService(_chatClient, _tools, _toolMode, _systemPrompt);
         _initialized = true;
     }
 

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -184,5 +184,5 @@ public class ChatService
     public Task<PromptResponse> BeginChatAsync(string userKey, string prompt) => Handler.BeginAsync(userKey, prompt);
     public Task<PromptResponse> ApproveFunctionAsync(string userKey, string functionId) => Handler.ApproveAsync(userKey, functionId);
     public Task<PromptResponse> DeclineFunctionAsync(string userKey, string functionId) => Handler.DeclineAsync(userKey, functionId);
-    public void Clear(string userKey) => Handler.ClearSession(userKey);
+    public void Clear(string userKey) => _promptingService?.ClearSession(userKey);
 }

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -43,6 +43,8 @@ public class ChatService
     private ApprovalMode _approvalMode = ApprovalMode.Auto;
     private FunctionCallingMode _functionCallingMode = FunctionCallingMode.Local;
     private ChatToolMode _toolMode = ChatToolMode.Auto;
+    private float? _temperature;
+    private string? _systemPrompt;
     private readonly ITokenAcquisition _tokenAcquisition;
 
     private PromptingService? _promptingService;
@@ -88,6 +90,24 @@ public class ChatService
         }
     }
 
+    public void SetTemperature(float? temperature)
+    {
+        if (_temperature != temperature)
+        {
+            _initialized = false;
+            _temperature = temperature;
+        }
+    }
+
+    public void SetSystemPrompt(string? systemPrompt)
+    {
+        if (_systemPrompt != systemPrompt)
+        {
+            _initialized = false;
+            _systemPrompt = systemPrompt;
+        }
+    }
+
     public async Task EnsureSetupAsync(IHttpClientFactory clientFactory)
     {
         if (_initialized) return;
@@ -108,7 +128,7 @@ public class ChatService
             _chatClient = new ChatClientBuilder(_chatClient).UseFunctionInvocation().Build();
         }
 
-        _promptingService = new PromptingService(_chatClient, _tools, _toolMode);
+        _promptingService = new PromptingService(_chatClient, _tools, _toolMode, _temperature, _systemPrompt);
         _initialized = true;
     }
 

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -16,9 +16,9 @@ public enum ApprovalMode
 {
     [Display(Name = "MEAI Auto-Invoke (no human approval)")]
     Auto,
-    [Display(Name = "Human Gate (approve / decline each tool call)")]
+    [Display(Name = "MEAI Human-in-the-loop (approve / decline each tool call)")]
     Manual,
-    [Display(Name = "Elicitation (MEAI auto-invoke + structured human input)")]
+    [Display(Name = "MCP Human in the loop (Eliciation)")]
     Elicitation
 }
 

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -14,11 +14,11 @@ namespace McpWebClient;
 
 public enum ApprovalMode
 {
-    [Display(Name = "Auto (no human approval)")]
+    [Display(Name = "MEAI Auto-Invoke (no human approval)")]
     Auto,
-    [Display(Name = "Manual Approval")]
+    [Display(Name = "Human Gate (approve / decline each tool call)")]
     Manual,
-    [Display(Name = "Elicitation Approval")]
+    [Display(Name = "Elicitation (MEAI auto-invoke + structured human input)")]
     Elicitation
 }
 

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -36,7 +36,7 @@ public class ChatService
 {
     private readonly IConfiguration _configuration;
     private readonly ElicitationCoordinator _elicitationCoordinator;
-    private IChatClient _chatClient;
+    private readonly IChatClient _baseChatClient;
     private IList<AIFunction> _tools = [];
     private McpClient _mcpClient = null!;
     private bool _initialized;
@@ -58,7 +58,7 @@ public class ChatService
             .AddEnvironmentVariables()
             .Build();
 
-        _chatClient = ChatClientHelper.GetChatClient(config);
+        _baseChatClient = ChatClientHelper.GetChatClient(config);
         _tokenAcquisition = tokenAcquisition;
     }
 
@@ -112,13 +112,15 @@ public class ChatService
             _tools = await _mcpClient.GetMcpToolsAsAIFunctionsAsync();
         }
 
+        var chatClient = _baseChatClient;
+
         // Wrap chat client with function invocation if using elicitation or auto mode (auto-invoke)
         if (_approvalMode is ApprovalMode.Elicitation or ApprovalMode.Auto)
         {
-            _chatClient = new ChatClientBuilder(_chatClient).UseFunctionInvocation().Build();
+            chatClient = new ChatClientBuilder(chatClient).UseFunctionInvocation().Build();
         }
 
-        _promptingService = new PromptingService(_chatClient, _tools, _toolMode, _systemPrompt);
+        _promptingService = new PromptingService(chatClient, _tools, _toolMode, _systemPrompt);
         _initialized = true;
     }
 

--- a/src/McpWebClient/AiServices/ChatService.cs
+++ b/src/McpWebClient/AiServices/ChatService.cs
@@ -42,6 +42,7 @@ public class ChatService
     private bool _initialized;
     private ApprovalMode _approvalMode = ApprovalMode.Auto;
     private FunctionCallingMode _functionCallingMode = FunctionCallingMode.Local;
+    private ChatToolMode _toolMode = ChatToolMode.Auto;
     private readonly ITokenAcquisition _tokenAcquisition;
 
     private PromptingService? _promptingService;
@@ -78,6 +79,15 @@ public class ChatService
         }
     }
 
+    public void SetToolMode(ChatToolMode mode)
+    {
+        if (_toolMode != mode)
+        {
+            _initialized = false;
+            _toolMode = mode;
+        }
+    }
+
     public async Task EnsureSetupAsync(IHttpClientFactory clientFactory)
     {
         if (_initialized) return;
@@ -100,7 +110,7 @@ public class ChatService
             _chatClient = new ChatClientBuilder(_chatClient).UseFunctionInvocation().Build();
         }
 
-        _promptingService = new PromptingService(_chatClient, _tools);
+        _promptingService = new PromptingService(_chatClient, _tools, _toolMode);
         _initialized = true;
     }
 
@@ -164,9 +174,17 @@ public class ChatService
              "Generates a random number based on a date.")
     ];
 
+    private IList<AIFunction> GetDateToolOnly() => [
+        AIFunctionFactory.Create(
+             () => DateTime.UtcNow.ToString("o"),
+             "GetCurrentDateTime",
+             "Returns the current date and time in ISO 8601 format.")
+    ];
+
     private PromptingService Handler => _promptingService ?? throw new InvalidOperationException("Service not initialized");
 
     public Task<PromptResponse> BeginChatAsync(string userKey, string prompt) => Handler.BeginAsync(userKey, prompt);
     public Task<PromptResponse> ApproveFunctionAsync(string userKey, string functionId) => Handler.ApproveAsync(userKey, functionId);
     public Task<PromptResponse> DeclineFunctionAsync(string userKey, string functionId) => Handler.DeclineAsync(userKey, functionId);
+    public void Clear(string userKey) => Handler.ClearSession(userKey);
 }

--- a/src/McpWebClient/AiServices/Models/PromptResponse.cs
+++ b/src/McpWebClient/AiServices/Models/PromptResponse.cs
@@ -1,3 +1,3 @@
 ﻿namespace McpWebClient.AiServices.Models;
 
-public record PromptResponse(string? FinalAnswer, List<PendingFunctionCall> PendingFunctions);
+public record PromptResponse(string? FinalAnswer, List<PendingFunctionCall> PendingFunctions, List<PendingFunctionCall>? ExecutedFunctions = null);

--- a/src/McpWebClient/AiServices/PromptingService.cs
+++ b/src/McpWebClient/AiServices/PromptingService.cs
@@ -11,17 +11,15 @@ internal partial class PromptingService
     private readonly IChatClient _chatClient;
     private readonly IList<AIFunction> _mcpTools;
     private readonly ChatToolMode _toolMode;
-    private readonly float? _temperature;
     private readonly string? _systemPrompt;
 
     private static readonly ConcurrentDictionary<string, ChatSession> _sessions = new();
 
-    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools, ChatToolMode? toolMode = null, float? temperature = null, string? systemPrompt = null)
+    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools, ChatToolMode? toolMode = null, string? systemPrompt = null)
     {
         _chatClient = chatClient;
         _mcpTools = mcpTools;
         _toolMode = toolMode ?? ChatToolMode.Auto;
-        _temperature = temperature;
         _systemPrompt = systemPrompt;
     }
 
@@ -76,7 +74,7 @@ internal partial class PromptingService
 
     private async Task<Microsoft.Extensions.AI.ChatResponse> ExecutePrompt(ChatSession session)
     {
-        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>(), _toolMode, _temperature);
+        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>(), _toolMode);
         var response = await _chatClient.GetResponseAsync(session.History, chatOptions);
         return response;
     }

--- a/src/McpWebClient/AiServices/PromptingService.cs
+++ b/src/McpWebClient/AiServices/PromptingService.cs
@@ -11,19 +11,27 @@ internal partial class PromptingService
     private readonly IChatClient _chatClient;
     private readonly IList<AIFunction> _mcpTools;
     private readonly ChatToolMode _toolMode;
+    private readonly float? _temperature;
+    private readonly string? _systemPrompt;
 
     private static readonly ConcurrentDictionary<string, ChatSession> _sessions = new();
 
-    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools, ChatToolMode? toolMode = null)
+    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools, ChatToolMode? toolMode = null, float? temperature = null, string? systemPrompt = null)
     {
         _chatClient = chatClient;
         _mcpTools = mcpTools;
         _toolMode = toolMode ?? ChatToolMode.Auto;
+        _temperature = temperature;
+        _systemPrompt = systemPrompt;
     }
 
     public async Task<PromptResponse> BeginAsync(string userKey, string prompt)
     {
         var session = _sessions[userKey] = new() { LastUpdatedUtc = DateTime.UtcNow };
+        if (!string.IsNullOrWhiteSpace(_systemPrompt))
+        {
+            session.History.Add(new ChatMessage(ChatRole.System, _systemPrompt));
+        }
         session.History.Add(new ChatMessage(ChatRole.User, prompt));
 
         var response = await ExecutePrompt(session);
@@ -68,7 +76,7 @@ internal partial class PromptingService
 
     private async Task<Microsoft.Extensions.AI.ChatResponse> ExecutePrompt(ChatSession session)
     {
-        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>(), _toolMode);
+        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>(), _toolMode, _temperature);
         var response = await _chatClient.GetResponseAsync(session.History, chatOptions);
         return response;
     }

--- a/src/McpWebClient/AiServices/PromptingService.cs
+++ b/src/McpWebClient/AiServices/PromptingService.cs
@@ -10,13 +10,15 @@ internal partial class PromptingService
 {
     private readonly IChatClient _chatClient;
     private readonly IList<AIFunction> _mcpTools;
+    private readonly ChatToolMode _toolMode;
 
     private static readonly ConcurrentDictionary<string, ChatSession> _sessions = new();
 
-    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools)
+    public PromptingService(IChatClient chatClient, IList<AIFunction> mcpTools, ChatToolMode? toolMode = null)
     {
         _chatClient = chatClient;
         _mcpTools = mcpTools;
+        _toolMode = toolMode ?? ChatToolMode.Auto;
     }
 
     public async Task<PromptResponse> BeginAsync(string userKey, string prompt)
@@ -54,7 +56,7 @@ internal partial class PromptingService
 
     private async Task<Microsoft.Extensions.AI.ChatResponse> ExecutePrompt(ChatSession session)
     {
-        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>());
+        var chatOptions = ChatClientHelper.CreateChatOptions(_mcpTools.Cast<AITool>(), _toolMode);
         var response = await _chatClient.GetResponseAsync(session.History, chatOptions);
         return response;
     }
@@ -122,6 +124,8 @@ internal partial class PromptingService
     }
 
     private void Clear(string userKey) => _sessions.TryRemove(userKey, out _);
+
+    public void ClearSession(string userKey) => Clear(userKey);
 
     private static List<PendingFunctionCall> Project(ChatSession session)
     {

--- a/src/McpWebClient/AiServices/PromptingService.cs
+++ b/src/McpWebClient/AiServices/PromptingService.cs
@@ -33,10 +33,22 @@ internal partial class PromptingService
             .OfType<FunctionCallContent>()
             .ToArray() ?? [];
 
-        return ExtractFunctionsAndSyncSession(session, lastMessage, functionCalls);
+        // Collect all function calls executed across the response messages
+        // (relevant for auto-invoke scenarios where calls don't surface as pending)
+        var executedCalls = response.Messages
+            .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
+            .Where(fc => !functionCalls.Any(p => p.CallId == fc.CallId))
+            .Select(fc => new PendingFunctionCall(
+                fc.CallId,
+                fc.Name,
+                string.Empty,
+                fc.Arguments != null ? JsonSerializer.Serialize(fc.Arguments) : string.Empty))
+            .ToList();
+
+        return ExtractFunctionsAndSyncSession(session, lastMessage, functionCalls, executedCalls);
     }
 
-    private static PromptResponse ExtractFunctionsAndSyncSession(ChatSession session, ChatMessage? lastMessage, FunctionCallContent[] functionCalls)
+    private static PromptResponse ExtractFunctionsAndSyncSession(ChatSession session, ChatMessage? lastMessage, FunctionCallContent[] functionCalls, List<PendingFunctionCall> executedCalls)
     {
         if (functionCalls.Length > 0 && lastMessage != null)
         {
@@ -46,12 +58,12 @@ internal partial class PromptingService
                 session.PendingCalls[call.CallId] = call;
             }
             session.LastUpdatedUtc = DateTime.UtcNow;
-            return new PromptResponse(null, Project(session));
+            return new PromptResponse(null, Project(session), executedCalls);
         }
 
         session.FinalAnswer = lastMessage?.Text;
         session.LastUpdatedUtc = DateTime.UtcNow;
-        return new PromptResponse(session.FinalAnswer, new());
+        return new PromptResponse(session.FinalAnswer, new(), executedCalls);
     }
 
     private async Task<Microsoft.Extensions.AI.ChatResponse> ExecutePrompt(ChatSession session)
@@ -114,7 +126,7 @@ internal partial class PromptingService
             .OfType<FunctionCallContent>()
             .ToArray() ?? [];
 
-        return ExtractFunctionsAndSyncSession(session, lastMessage, moreCalls);
+        return ExtractFunctionsAndSyncSession(session, lastMessage, moreCalls, new());
     }
 
     public Task<PromptResponse> DeclineAsync(string userKey, string functionId)

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml
@@ -34,9 +34,17 @@
                     <div class="mb-3 pb-3 border-bottom">
                         <label class="form-label fw-semibold mb-2" for="SelectedToolModeValue">Tool Mode:</label>
                         <select class="form-select form-select-sm" id="SelectedToolModeValue" name="SelectedToolModeValue" asp-for="SelectedToolModeValue">
-                            <option value="Auto">Auto (Model decides)</option>
                             <option value="None">None (No tools)</option>
+                            <option value="Auto">Auto (Model decides)</option>
+                            <option value="RequireAny">RequireAny (Must use a tool)</option>
                         </select>
+
+                        <div class="form-check mt-3">
+                            <input class="form-check-input" type="checkbox" id="DisableSystemPrompt" asp-for="DisableSystemPrompt" />
+                            <label class="form-check-label small" for="DisableSystemPrompt">
+                                Disable system prompt (send empty system prompt)
+                            </label>
+                        </div>
                     </div>
 
                     <div class="mb-2">
@@ -103,38 +111,5 @@
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════
-     Information Panel
+     (Tool Mode Explanation panel removed)
      ═══════════════════════════════════════════════════════════════════════ -->
-<div class="row mt-3">
-    <div class="col-12">
-        <div class="card shadow-sm">
-            <div class="card-header fw-semibold">ℹ️ Tool Mode Explanation</div>
-            <div class="card-body py-2">
-                <div class="row">
-                    <div class="col-md-6">
-                        <div>
-                            <strong class="text-primary">Auto</strong>
-                            <small class="d-block text-muted">The model decides whether to call tools or respond directly. Useful for flexible interactions.</small>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div>
-                            <strong class="text-secondary">None</strong>
-                            <small class="d-block text-muted">The model cannot use tools. Only text-based responses allowed.</small>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-@section Scripts {
-    <script>
-        // Auto-update tool mode when selector changes
-        document.getElementById('SelectedToolMode')?.addEventListener('change', function() {
-            // Optional: You could submit form on change for real-time updates
-            // this.closest('form').submit();
-        });
-    </script>
-}

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml
@@ -28,9 +28,9 @@
                             <label class="form-label fw-semibold mb-2">Tool Mode:</label>
                         </div>
                         <div class="col-auto">
-                            <select class="form-select form-select-sm" id="SelectedToolMode" name="SelectedToolMode" asp-for="SelectedToolMode">
-                                <option value="@ChatToolMode.Auto" selected="@(Model.SelectedToolMode == ChatToolMode.Auto)">Auto (Model decides)</option>
-                                <option value="@ChatToolMode.None" selected="@(Model.SelectedToolMode == ChatToolMode.None)">None (No tools)</option>
+                            <select class="form-select form-select-sm" id="SelectedToolModeValue" name="SelectedToolModeValue">
+                                <option value="Auto" selected="@(Model.SelectedToolModeValue == "Auto")">Auto (Model decides)</option>
+                                <option value="None" selected="@(Model.SelectedToolModeValue == "None")">None (No tools)</option>
                             </select>
                         </div>
                     </div>

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml
@@ -29,26 +29,19 @@
                     </div>
                 }
 
-                <!-- ToolMode Selector -->
-                <form method="post" asp-page="FunctionCalling" class="mb-3 pb-3 border-bottom">
-                    <div class="row g-2">
-                        <div class="col-auto">
-                            <label class="form-label fw-semibold mb-2">Tool Mode:</label>
-                        </div>
-                        <div class="col-auto">
-                            <select class="form-select form-select-sm" id="SelectedToolModeValue" name="SelectedToolModeValue">
-                                <option value="Auto" selected="@(Model.SelectedToolModeValue == "Auto")">Auto (Model decides)</option>
-                                <option value="None" selected="@(Model.SelectedToolModeValue == "None")">None (No tools)</option>
-                            </select>
-                        </div>
+                <!-- Single combined form: ToolMode + Prompt -->
+                <form method="post" asp-page="FunctionCalling">
+                    <div class="mb-3 pb-3 border-bottom">
+                        <label class="form-label fw-semibold mb-2" for="SelectedToolModeValue">Tool Mode:</label>
+                        <select class="form-select form-select-sm" id="SelectedToolModeValue" name="SelectedToolModeValue" asp-for="SelectedToolModeValue">
+                            <option value="Auto">Auto (Model decides)</option>
+                            <option value="None">None (No tools)</option>
+                        </select>
                     </div>
-                </form>
 
-                <!-- Prompt Input -->
-                <form method="post" class="mt-auto">
                     <div class="mb-2">
-                        <label class="form-label fw-semibold">Prompt:</label>
-                        <textarea class="form-control" rows="4" name="Prompt"
+                        <label class="form-label fw-semibold" asp-for="Prompt">Prompt:</label>
+                        <textarea class="form-control" rows="4"
                                   placeholder="Ask something like: What is the current date?"
                                   asp-for="Prompt"></textarea>
                     </div>

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml
@@ -21,6 +21,14 @@
             </div>
             <div class="card-body d-flex flex-column" style="min-height:520px;">
 
+                <!-- Error Message -->
+                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <div class="alert alert-danger small py-2 mb-3">
+                        <strong>⚠️ Error:</strong> @Model.ErrorMessage
+                    </div>
+                }
+
                 <!-- ToolMode Selector -->
                 <form method="post" asp-page="FunctionCalling" class="mb-3 pb-3 border-bottom">
                     <div class="row g-2">
@@ -47,18 +55,12 @@
                     <button type="submit" class="btn btn-primary w-100">Send Prompt</button>
                 </form>
 
-                <!-- Error Message -->
-                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-                {
-                    <div class="alert alert-danger small py-2 mt-3">@Model.ErrorMessage</div>
-                }
-
                 <!-- Results -->
                 @if (!string.IsNullOrEmpty(Model.PromptResults))
                 {
                     <div class="alert alert-info small py-2 mt-3 mb-0">
-                        <strong>Response:</strong>
-                        <div class="mt-2">@Model.PromptResults</div>
+                        <strong>📝 Response:</strong>
+                        <div class="mt-2" style="white-space: pre-wrap;">@Model.PromptResults</div>
                     </div>
                 }
             </div>
@@ -70,7 +72,7 @@
          ═══════════════════════════════════════════════════════════════════════ -->
     <div class="col-md-6">
         <div class="card shadow-sm">
-            <div class="card-header fw-semibold">🔧 DateTool Calls</div>
+            <div class="card-header fw-semibold">🔧 Function Calls</div>
             <div class="card-body" style="max-height:600px; overflow-y:auto;">
                 @if (!hasPendingFunctions)
                 {

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml
@@ -1,0 +1,145 @@
+@page
+@model FunctionCallingModel
+@using Microsoft.Extensions.AI
+@{
+    ViewData["Title"] = "Function Calling Test";
+    var hasPendingFunctions = Model.PendingFunctions.Any();
+}
+
+<div class="row g-3">
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         LEFT – Chat Panel with ToolMode Selector
+         ═══════════════════════════════════════════════════════════════════════ -->
+    <div class="col-md-6">
+        <div class="card h-100 shadow-sm">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span class="fw-semibold">📅 Function Calling Test</span>
+                <form method="post" asp-page-handler="Clear" class="mb-0">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </form>
+            </div>
+            <div class="card-body d-flex flex-column" style="min-height:520px;">
+
+                <!-- ToolMode Selector -->
+                <form method="post" asp-page="FunctionCalling" class="mb-3 pb-3 border-bottom">
+                    <div class="row g-2">
+                        <div class="col-auto">
+                            <label class="form-label fw-semibold mb-2">Tool Mode:</label>
+                        </div>
+                        <div class="col-auto">
+                            <select class="form-select form-select-sm" id="SelectedToolMode" name="SelectedToolMode" asp-for="SelectedToolMode">
+                                <option value="@ChatToolMode.Auto" selected="@(Model.SelectedToolMode == ChatToolMode.Auto)">Auto (Model decides)</option>
+                                <option value="@ChatToolMode.None" selected="@(Model.SelectedToolMode == ChatToolMode.None)">None (No tools)</option>
+                            </select>
+                        </div>
+                    </div>
+                </form>
+
+                <!-- Prompt Input -->
+                <form method="post" class="mt-auto">
+                    <div class="mb-2">
+                        <label class="form-label fw-semibold">Prompt:</label>
+                        <textarea class="form-control" rows="4" name="Prompt"
+                                  placeholder="Ask something like: What is the current date?"
+                                  asp-for="Prompt"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Send Prompt</button>
+                </form>
+
+                <!-- Error Message -->
+                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <div class="alert alert-danger small py-2 mt-3">@Model.ErrorMessage</div>
+                }
+
+                <!-- Results -->
+                @if (!string.IsNullOrEmpty(Model.PromptResults))
+                {
+                    <div class="alert alert-info small py-2 mt-3 mb-0">
+                        <strong>Response:</strong>
+                        <div class="mt-2">@Model.PromptResults</div>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         RIGHT – Tool Calls Panel
+         ═══════════════════════════════════════════════════════════════════════ -->
+    <div class="col-md-6">
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold">🔧 DateTool Calls</div>
+            <div class="card-body" style="max-height:600px; overflow-y:auto;">
+                @if (!hasPendingFunctions)
+                {
+                    <p class="text-muted fst-italic small mb-0">Tool calls will appear here after sending a prompt.</p>
+                }
+                else
+                {
+                    <div class="d-flex flex-column gap-3">
+                        @foreach (var call in Model.PendingFunctions)
+                        {
+                            <div class="border rounded p-3 bg-light">
+                                <div class="fw-semibold small mb-2">📍 @call.FunctionName</div>
+                                @if (!string.IsNullOrWhiteSpace(call.ArgumentsJson))
+                                {
+                                    <div class="mb-2">
+                                        <small class="text-muted">Arguments:</small>
+                                        <pre class="bg-white p-2 rounded mb-0" style="font-size:0.75rem; max-height:150px; overflow-y:auto;">@call.ArgumentsJson</pre>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <small class="text-muted d-block mb-2">No arguments</small>
+                                }
+                                <div class="text-muted small">
+                                    <code>ID: @call.Id</code>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Information Panel
+     ═══════════════════════════════════════════════════════════════════════ -->
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card shadow-sm">
+            <div class="card-header fw-semibold">ℹ️ Tool Mode Explanation</div>
+            <div class="card-body py-2">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div>
+                            <strong class="text-primary">Auto</strong>
+                            <small class="d-block text-muted">The model decides whether to call tools or respond directly. Useful for flexible interactions.</small>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div>
+                            <strong class="text-secondary">None</strong>
+                            <small class="d-block text-muted">The model cannot use tools. Only text-based responses allowed.</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        // Auto-update tool mode when selector changes
+        document.getElementById('SelectedToolMode')?.addEventListener('change', function() {
+            // Optional: You could submit form on change for real-time updates
+            // this.closest('form').submit();
+        });
+    </script>
+}

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using McpWebClient.AiServices.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.AI;
+using Microsoft.Identity.Web;
+
+namespace McpWebClient.Pages;
+
+[AuthorizeForScopes(ScopeKeySection = "McpDemoScope")]
+public class FunctionCallingModel : PageModel
+{
+    private readonly ILogger<FunctionCallingModel> _logger;
+    private readonly ChatService _chatService;
+    private readonly IHttpClientFactory _clientFactory;
+
+    [BindProperty]
+    public string? PromptResults { get; set; }
+
+    [BindProperty]
+    [Required]
+    public string Prompt { get; set; } = "What is the current date?";
+
+    [BindProperty]
+    [Required]
+    public ChatToolMode SelectedToolMode { get; set; } = ChatToolMode.Auto;
+
+    public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
+    public string? ErrorMessage { get; private set; }
+
+    public FunctionCallingModel(ILogger<FunctionCallingModel> logger,
+        IHttpClientFactory clientFactory,
+        ChatService chatService)
+    {
+        _clientFactory = clientFactory;
+        _logger = logger;
+        _chatService = chatService;
+    }
+
+    public IActionResult OnGet()
+    {
+        return Page();
+    }
+
+    private string GetUserKey() =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name ?? "anonymous";
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return OnGet();
+        }
+
+        try
+        {
+            await EnsureChatServiceSetupAsync();
+            var userKey = GetUserKey();
+
+            var response = await _chatService.BeginChatAsync(userKey, Prompt);
+            PromptResults = response.FinalAnswer;
+            PendingFunctions = response.PendingFunctions;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            _logger.LogError(ex, "Error processing prompt");
+        }
+
+        return Page();
+    }
+
+    public IActionResult OnPostClear()
+    {
+        _chatService.Clear(GetUserKey());
+        return RedirectToPage();
+    }
+
+    private async Task EnsureChatServiceSetupAsync()
+    {
+        _chatService.SetToolMode(SelectedToolMode);
+        _chatService.SetFunctionCallingMode(FunctionCallingMode.Local);
+        _chatService.SetApprovalMode(ApprovalMode.Auto);
+        await _chatService.EnsureSetupAsync(_clientFactory);
+    }
+}

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -24,7 +24,13 @@ public class FunctionCallingModel : PageModel
 
     [BindProperty]
     [Required]
-    public ChatToolMode SelectedToolMode { get; set; } = ChatToolMode.Auto;
+    public string SelectedToolModeValue { get; set; } = "Auto";
+
+    public ChatToolMode SelectedToolMode => SelectedToolModeValue switch
+    {
+        "None" => ChatToolMode.None,
+        _ => ChatToolMode.Auto
+    };
 
     public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
     public string? ErrorMessage { get; private set; }

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -105,11 +105,21 @@ public class FunctionCallingModel : PageModel
         return RedirectToPage();
     }
 
+    private const string StrictSystemPrompt =
+        "You are a strict assistant for a function-calling demo. " +
+        "Only answer questions if you can use a provided tool to obtain the data. " +
+        "If no tool can provide the answer (for example: current date, current time, " +
+        "live data, or anything you cannot verify), you MUST reply exactly: " +
+        "\"I cannot answer this without an appropriate tool.\" " +
+        "Do not guess. Do not use training data. Do not estimate.";
+
     private async Task EnsureChatServiceSetupAsync()
     {
         _chatService.SetToolMode(SelectedToolMode);
         _chatService.SetFunctionCallingMode(FunctionCallingMode.Local);
         _chatService.SetApprovalMode(ApprovalMode.Auto);
+        _chatService.SetTemperature(0f);
+        _chatService.SetSystemPrompt(StrictSystemPrompt);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }
 }

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -32,8 +32,11 @@ public class FunctionCallingModel : PageModel
         _ => ChatToolMode.Auto
     };
 
+    [BindProperty]
     public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
-    public string? ErrorMessage { get; private set; }
+    
+    [BindProperty]
+    public string? ErrorMessage { get; set; }
 
     public FunctionCallingModel(ILogger<FunctionCallingModel> logger,
         IHttpClientFactory clientFactory,
@@ -56,7 +59,9 @@ public class FunctionCallingModel : PageModel
     {
         if (!ModelState.IsValid)
         {
-            return OnGet();
+            ErrorMessage = "Model validation failed.";
+            _logger.LogWarning("Model state invalid: {errors}", string.Join("; ", ModelState.Values.SelectMany(v => v.Errors)));
+            return Page();
         }
 
         try
@@ -64,14 +69,19 @@ public class FunctionCallingModel : PageModel
             await EnsureChatServiceSetupAsync();
             var userKey = GetUserKey();
 
+            _logger.LogInformation("Processing prompt: {Prompt} with ToolMode: {ToolMode}", Prompt, SelectedToolModeValue);
             var response = await _chatService.BeginChatAsync(userKey, Prompt);
+            
             PromptResults = response.FinalAnswer;
-            PendingFunctions = response.PendingFunctions;
+            PendingFunctions = response.PendingFunctions ?? new();
+            
+            _logger.LogInformation("Response received: {FinalAnswer}, PendingFunctions: {Count}", 
+                response.FinalAnswer, response.PendingFunctions?.Count ?? 0);
         }
         catch (Exception ex)
         {
-            ErrorMessage = ex.Message;
-            _logger.LogError(ex, "Error processing prompt");
+            ErrorMessage = $"Error: {ex.Message}";
+            _logger.LogError(ex, "Error processing prompt: {Message}", ex.Message);
         }
 
         return Page();
@@ -80,6 +90,9 @@ public class FunctionCallingModel : PageModel
     public IActionResult OnPostClear()
     {
         _chatService.Clear(GetUserKey());
+        PendingFunctions = new();
+        PromptResults = null;
+        ErrorMessage = null;
         return RedirectToPage();
     }
 

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -15,7 +15,6 @@ public class FunctionCallingModel : PageModel
     private readonly ChatService _chatService;
     private readonly IHttpClientFactory _clientFactory;
 
-    [BindProperty]
     public string? PromptResults { get; set; }
 
     [BindProperty]
@@ -32,10 +31,8 @@ public class FunctionCallingModel : PageModel
         _ => ChatToolMode.Auto
     };
 
-    [BindProperty]
     public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
     
-    [BindProperty]
     public string? ErrorMessage { get; set; }
 
     public FunctionCallingModel(ILogger<FunctionCallingModel> logger,

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -118,7 +118,8 @@ public class FunctionCallingModel : PageModel
         _chatService.SetToolMode(SelectedToolMode);
         _chatService.SetFunctionCallingMode(FunctionCallingMode.Local);
         _chatService.SetApprovalMode(ApprovalMode.Auto);
-        _chatService.SetTemperature(0f);
+        // Note: Temperature is intentionally NOT set — reasoning models (o1/o3/gpt-5)
+        // only support the default value. Determinism is enforced via the system prompt.
         _chatService.SetSystemPrompt(StrictSystemPrompt);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -72,8 +72,20 @@ public class FunctionCallingModel : PageModel
             PromptResults = response.FinalAnswer;
             PendingFunctions = response.PendingFunctions ?? new();
             
-            _logger.LogInformation("Response received: {FinalAnswer}, PendingFunctions: {Count}", 
-                response.FinalAnswer, response.PendingFunctions?.Count ?? 0);
+            // Merge executed calls (auto-invoked) into the display list
+            if (response.ExecutedFunctions != null && response.ExecutedFunctions.Count > 0)
+            {
+                foreach (var executed in response.ExecutedFunctions)
+                {
+                    if (!PendingFunctions.Any(p => p.Id == executed.Id))
+                    {
+                        PendingFunctions.Add(executed);
+                    }
+                }
+            }
+            
+            _logger.LogInformation("Response received: {FinalAnswer}, PendingFunctions: {Count}, ExecutedFunctions: {ExecCount}", 
+                response.FinalAnswer, response.PendingFunctions?.Count ?? 0, response.ExecutedFunctions?.Count ?? 0);
         }
         catch (Exception ex)
         {

--- a/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
+++ b/src/McpWebClient/Pages/FunctionCalling.cshtml.cs
@@ -23,13 +23,17 @@ public class FunctionCallingModel : PageModel
 
     [BindProperty]
     [Required]
-    public string SelectedToolModeValue { get; set; } = "Auto";
+    public string SelectedToolModeValue { get; set; } = "None";
 
     public ChatToolMode SelectedToolMode => SelectedToolModeValue switch
     {
         "None" => ChatToolMode.None,
+        "RequireAny" => ChatToolMode.RequireAny,
         _ => ChatToolMode.Auto
     };
+
+    [BindProperty]
+    public bool DisableSystemPrompt { get; set; }
 
     public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
     
@@ -120,7 +124,7 @@ public class FunctionCallingModel : PageModel
         _chatService.SetApprovalMode(ApprovalMode.Auto);
         // Note: Temperature is intentionally NOT set — reasoning models (o1/o3/gpt-5)
         // only support the default value. Determinism is enforced via the system prompt.
-        _chatService.SetSystemPrompt(StrictSystemPrompt);
+        _chatService.SetSystemPrompt(DisableSystemPrompt ? null : StrictSystemPrompt);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }
 }

--- a/src/McpWebClient/Pages/Index.cshtml
+++ b/src/McpWebClient/Pages/Index.cshtml
@@ -1,7 +1,7 @@
-﻿@page
+@page "/McpAuthDemo"
 @model IndexModel
 @{
-    ViewData["Title"] = "Lets MCP it";
+    ViewData["Title"] = "MCP Auth Demo";
 }
 
 <!-- Explicit asp-page to avoid inheriting any existing ?handler=Approve query when reusing page URL -->

--- a/src/McpWebClient/Pages/Index.cshtml
+++ b/src/McpWebClient/Pages/Index.cshtml
@@ -3,23 +3,29 @@
 @{
     ViewData["Title"] = "MCP Auth Demo";
 }
+@* This page always connects via Confidential OIDC MCP (McpSecure).
+   The access token is acquired via ITokenAcquisition (Microsoft.Identity.Web)
+   and sent as a Bearer token to the HttpMcpServer. *@
+
+<!-- Transport badge -->
+<div class="alert alert-secondary d-flex align-items-center gap-2 py-2 mb-3" role="alert">
+    <span class="badge bg-dark">🔒 Confidential OIDC MCP</span>
+    <small class="text-muted">Token acquired via <code>ITokenAcquisition</code> and forwarded to the MCP server as a Bearer token.</small>
+</div>
 
 <!-- Explicit asp-page to avoid inheriting any existing ?handler=Approve query when reusing page URL -->
 <form method="post" asp-page="Index">
     <div class="mb-3">
-        <label class="form-label" for="SelectedFunctionCallingMode">Function Calling Mode:</label>
-        <select class="form-select" id="SelectedFunctionCallingMode" name="SelectedFunctionCallingMode"
-                asp-for="SelectedFunctionCallingMode"
-                asp-items="Html.GetEnumSelectList<FunctionCallingMode>()"></select>
-        <span asp-validation-for="SelectedFunctionCallingMode" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label class="form-label" for="SelectedMode">Approval Mode:</label>
+        <label class="form-label" for="SelectedMode">Tool Invocation Mode:</label>
         <select class="form-select" id="SelectedMode" name="SelectedMode"
                 asp-for="SelectedMode"
                 asp-items="Html.GetEnumSelectList<ApprovalMode>()"></select>
         <span asp-validation-for="SelectedMode" class="text-danger"></span>
+        <div class="form-text">
+            <strong>MEAI Auto-Invoke</strong> — the MEAI <code>UseFunctionInvocation()</code> middleware calls all tools automatically and returns the final answer.<br />
+            <strong>Human Gate</strong> — MEAI returns raw tool-call requests; you approve or decline each one individually below.<br />
+            <strong>Elicitation</strong> — MEAI auto-invokes tools but may pause to collect structured user input via MCP Elicitation forms.
+        </div>
     </div>
 
     <div class="mb-3 mt-3">
@@ -38,9 +44,9 @@
 @if (Model.PendingFunctions.Any())
 {
     <div class="card mt-4">
-        <div class="card-header">Pending Tool Approvals (@Model.PendingFunctions.Count)</div>
+        <div class="card-header">⏳ Awaiting Human Gate — @Model.PendingFunctions.Count tool call(s) pending</div>
         <div class="card-body">
-            <p>The model requested the following tool calls. Approve or decline individually.</p>
+            <p class="text-muted small mb-3">The model requested the following tool calls. Approve to execute them, or decline to cancel.</p>
             <ul class="list-group">
                 @foreach (var f in Model.PendingFunctions)
                 {
@@ -54,14 +60,12 @@
                                 <form method="post" asp-page-handler="Approve" asp-route-functionId="@f.Id" class="d-inline">
                                     <input type="hidden" name="Prompt" value="@Model.Prompt" />
                                     <input type="hidden" name="SelectedMode" value="@Model.SelectedMode" />
-                                    <input type="hidden" name="SelectedFunctionCallingMode" value="@Model.SelectedFunctionCallingMode" />
-                                    <button type="submit" class="btn btn-sm btn-success me-1">Approve</button>
+                                    <button type="submit" class="btn btn-sm btn-success me-1">✔ Approve</button>
                                 </form>
                                 <form method="post" asp-page-handler="Decline" asp-route-functionId="@f.Id" class="d-inline">
                                     <input type="hidden" name="Prompt" value="@Model.Prompt" />
                                     <input type="hidden" name="SelectedMode" value="@Model.SelectedMode" />
-                                    <input type="hidden" name="SelectedFunctionCallingMode" value="@Model.SelectedFunctionCallingMode" />
-                                    <button type="submit" class="btn btn-sm btn-danger">Decline</button>
+                                    <button type="submit" class="btn btn-sm btn-danger">✖ Decline</button>
                                 </form>
                             </div>
                         </div>

--- a/src/McpWebClient/Pages/Index.cshtml
+++ b/src/McpWebClient/Pages/Index.cshtml
@@ -22,8 +22,8 @@
         <span asp-validation-for="SelectedMode" class="text-danger"></span>
         <div class="form-text">
             <strong>MEAI Auto-Invoke</strong> — the MEAI <code>UseFunctionInvocation()</code> middleware calls all tools automatically and returns the final answer.<br />
-            <strong>Human Gate</strong> — MEAI returns raw tool-call requests; you approve or decline each one individually below.<br />
-            <strong>Elicitation</strong> — MEAI auto-invokes tools but may pause to collect structured user input via MCP Elicitation forms.
+            <strong>MEAI Human-in-the-loop</strong> — MEAI returns raw tool-call requests; you approve or decline each call explicitly in this page.<br />
+            <strong>MCP Human in the loop (Eliciation)</strong> — MEAI auto-invokes tools, but each tool execution requests approval via MCP Elicitation before it proceeds.
         </div>
     </div>
 
@@ -43,7 +43,7 @@
 @if (Model.PendingFunctions.Any())
 {
     <div class="card mt-4">
-        <div class="card-header">⏳ Awaiting Human Gate — @Model.PendingFunctions.Count tool call(s) pending</div>
+        <div class="card-header">⏳ Awaiting MEAI Human-in-the-loop — @Model.PendingFunctions.Count tool call(s) pending</div>
         <div class="card-body">
             <p class="text-muted small mb-3">The model requested the following tool calls. Approve to execute them, or decline to cancel.</p>
             <ul class="list-group">

--- a/src/McpWebClient/Pages/Index.cshtml
+++ b/src/McpWebClient/Pages/Index.cshtml
@@ -13,8 +13,7 @@
     <small class="text-muted">Token acquired via <code>ITokenAcquisition</code> and forwarded to the MCP server as a Bearer token.</small>
 </div>
 
-<!-- Explicit asp-page to avoid inheriting any existing ?handler=Approve query when reusing page URL -->
-<form method="post" asp-page="Index">
+<form method="post">
     <div class="mb-3">
         <label class="form-label" for="SelectedMode">Tool Invocation Mode:</label>
         <select class="form-select" id="SelectedMode" name="SelectedMode"

--- a/src/McpWebClient/Pages/Index.cshtml.cs
+++ b/src/McpWebClient/Pages/Index.cshtml.cs
@@ -23,10 +23,6 @@ public class IndexModel : PageModel
 
     [BindProperty]
     [Required]
-    public FunctionCallingMode SelectedFunctionCallingMode { get; set; } = FunctionCallingMode.Local;
-
-    [BindProperty]
-    [Required]
     public ApprovalMode SelectedMode { get; set; } = ApprovalMode.Auto;
 
     public List<PendingFunctionCall> PendingFunctions { get; set; } = new();
@@ -88,7 +84,8 @@ public class IndexModel : PageModel
     private async Task EnsureChatServiceSetupAsync()
     {
         _chatService.SetApprovalMode(SelectedMode);
-        _chatService.SetFunctionCallingMode(SelectedFunctionCallingMode);
+        // Always uses Confidential OIDC MCP (McpSecure) — token acquired via ITokenAcquisition
+        _chatService.SetFunctionCallingMode(FunctionCallingMode.McpSecure);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }
 

--- a/src/McpWebClient/Pages/Index.cshtml.cs
+++ b/src/McpWebClient/Pages/Index.cshtml.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using McpWebClient.AiServices.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.AI;
 using Microsoft.Identity.Web;
 
 namespace McpWebClient.Pages;
@@ -86,6 +87,9 @@ public class IndexModel : PageModel
         _chatService.SetApprovalMode(SelectedMode);
         // Always uses Confidential OIDC MCP (McpSecure) — token acquired via ITokenAcquisition
         _chatService.SetFunctionCallingMode(FunctionCallingMode.McpSecure);
+        _chatService.SetToolMode(SelectedMode is ApprovalMode.Manual or ApprovalMode.Elicitation
+            ? ChatToolMode.RequireAny
+            : ChatToolMode.Auto);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }
 

--- a/src/McpWebClient/Pages/Index.cshtml.cs
+++ b/src/McpWebClient/Pages/Index.cshtml.cs
@@ -87,9 +87,7 @@ public class IndexModel : PageModel
         _chatService.SetApprovalMode(SelectedMode);
         // Always uses Confidential OIDC MCP (McpSecure) — token acquired via ITokenAcquisition
         _chatService.SetFunctionCallingMode(FunctionCallingMode.McpSecure);
-        _chatService.SetToolMode(SelectedMode is ApprovalMode.Manual or ApprovalMode.Elicitation
-            ? ChatToolMode.RequireAny
-            : ChatToolMode.Auto);
+        _chatService.SetToolMode(ChatToolMode.Auto);
         await _chatService.EnsureSetupAsync(_clientFactory);
     }
 

--- a/src/McpWebClient/Pages/Shared/_Layout.cshtml
+++ b/src/McpWebClient/Pages/Shared/_Layout.cshtml
@@ -24,7 +24,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/FunctionCalling">Function Calling</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Advanced Demo</a>
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">MCP Auth Demo</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/SalesAssistant">Sales Assistant</a>

--- a/src/McpWebClient/Pages/Shared/_Layout.cshtml
+++ b/src/McpWebClient/Pages/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-page="/Index">LLM with MCP server</a>
+                <a class="navbar-brand" asp-area="" asp-page="/FunctionCalling">LLM with MCP server</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -21,7 +21,10 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-page="/FunctionCalling">Function Calling</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Advanced Demo</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/SalesAssistant">Sales Assistant</a>

--- a/src/McpWebClient/Program.cs
+++ b/src/McpWebClient/Program.cs
@@ -62,6 +62,9 @@ public class Program
         app.MapControllers();
         app.MapHub<ElicitationHub>("/hubs/elicitation");
 
+        // Redirect root to FunctionCalling page
+        app.MapGet("/", () => Results.Redirect("/FunctionCalling"));
+
         app.Run();
     }
 }

--- a/src/UnsecureHttpMcpServer/Program.cs
+++ b/src/UnsecureHttpMcpServer/Program.cs
@@ -10,10 +10,7 @@ builder.Services.AddTransient<SalesTools>();
 
 builder.Services
        .AddMcpServer()
-       .WithHttpTransport(options =>
-       {
-           options.Stateless = true;
-       })
+       .WithHttpTransport()
        .WithPrompts<PromptExamples>()
        .WithResources<DocumentationResource>()
        .WithTools<RandomNumberTools>()


### PR DESCRIPTION
## Summary
- add a FunctionCalling page with ToolMode controls and improved function call surfacing
- rename and refine the MCP Auth Demo flows, labels, and elicitation behavior
- tighten ChatService and prompting plumbing, including safer clear handling and updated controls

## Testing
- not run